### PR TITLE
Introduction of certificateKeys and accountKeys variables

### DIFF
--- a/LEClient/src/LEAccount.php
+++ b/LEClient/src/LEAccount.php
@@ -4,21 +4,21 @@
  * LetsEncrypt Account class, containing the functions and data associated with a LetsEncrypt account.
  *
  * PHP version 7.1.0
- * 
+ *
  * MIT License
- * 
+ *
  * Copyright (c) 2018 Youri van Weegberg
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -37,8 +37,8 @@
 class LEAccount
 {
 	private $connector;
-	private $accountKeysDir;
-	
+	private $accountKeys;
+
 	public $id;
 	public $key;
 	public $contact;
@@ -46,27 +46,27 @@ class LEAccount
 	public $initialIp;
 	public $createdAt;
 	public $status;
-	
+
 	private $log;
-	
+
     /**
      * Initiates the LetsEncrypt Account class.
-     * 
+     *
      * @param LEConnector	$connector 		The LetsEncrypt Connector instance to use for HTTP requests.
      * @param int 			$log 			The level of logging. Defaults to no logging. LOG_OFF, LOG_STATUS, LOG_DEBUG accepted.
      * @param array 		$email	 		The array of strings containing e-mail addresses. Only used when creating a new account.
-     * @param string 		$accountKeysDir The directory in which the account keys are stored. Is a subdir inside $keysDir.
+     * @param array 		$accountKeys Array containing location of account keys files.
      */
-	public function __construct($connector, $log, $email, $accountKeysDir)
+	public function __construct($connector, $log, $email, $accountKeys)
 	{
 		$this->connector = $connector;
-		$this->accountKeysDir = $accountKeysDir;
+		$this->accountKeys = $accountKeys;
 		$this->log = $log;
-		
-		if(!file_exists($this->accountKeysDir . 'private.pem') OR !file_exists($this->accountKeysDir . 'public.pem')) 
+
+		if(!file_exists($this->accountKeys['private_key']) OR !file_exists($this->accountKeys['public_key']))
 		{
 			if($this->log >= LECLient::LOG_STATUS) LEFunctions::log('No account found, attempting to create account.', 'function LEAccount __construct');
-			LEFunctions::RSAgenerateKeys($this->accountKeysDir);
+			LEFunctions::RSAgenerateKeys(null, $this->accountKeys['private_key'], $this->accountKeys['public_key']);
 			$this->connector->accountURL = $this->createLEAccount($email);
 		}
 		else
@@ -76,18 +76,18 @@ class LEAccount
 		if($this->connector->accountURL == false) throw new \RuntimeException('Account not found or deactivated.');
 		$this->getLEAccountData();
 	}
-	
+
     /**
      * Creates a new LetsEncrypt account.
-     * 
+     *
      * @param array 	$email 	The array of strings containing e-mail addresses.
-     * 
+     *
      * @return object	Returns the new account URL when the account was successfully created, false if not.
      */
 	private function createLEAccount($email)
 	{
 		$contact = array_map(function($addr) { return empty($addr) ? '' : (strpos($addr, 'mailto') === false ? 'mailto:' . $addr : $addr); }, $email);
-		
+
 		$sign = $this->connector->signRequestJWK(array('contact' => $contact, 'termsOfServiceAgreed' => true), $this->connector->newAccount);
 		$post = $this->connector->post($this->connector->newAccount, $sign);
 		if(strpos($post['header'], "201 Created") !== false)
@@ -96,24 +96,24 @@ class LEAccount
 		}
 		return false;
 	}
-	
+
     /**
      * Gets the LetsEncrypt account URL associated with the stored account keys.
-     * 
-     * @return object	Returns the account URL if it is found, or false when none is found.	
+     *
+     * @return object	Returns the account URL if it is found, or false when none is found.
      */
 	private function getLEAccount()
 	{
 		$sign = $this->connector->signRequestJWK(array('onlyReturnExisting' => true), $this->connector->newAccount);
 		$post = $this->connector->post($this->connector->newAccount, $sign);
-		
+
 		if(strpos($post['header'], "200 OK") !== false)
 		{
 			if(preg_match('~Location: (\S+)~i', $post['header'], $matches)) return trim($matches[1]);
 		}
 		return false;
 	}
-	
+
     /**
      * Gets the LetsEncrypt account data from the account URL.
      */
@@ -136,18 +136,18 @@ class LEAccount
 			throw new \RuntimeException('Account data cannot be found.');
 		}
 	}
-	
+
     /**
      * Updates account data. Now just supporting new contact information.
-     * 
+     *
      * @param array 	$email	The array of strings containing e-mail adresses.
-     * 
+     *
      * @return boolean	Returns true if the update is successful, false if not.
      */
 	public function updateAccount($email)
 	{
 		$contact = array_map(function($addr) { return empty($addr) ? '' : (strpos($addr, 'mailto') === false ? 'mailto:' . $addr : $addr); }, $email);
-		
+
 		$sign = $this->connector->signRequestKid(array('contact' => $contact), $this->connector->accountURL, $this->connector->accountURL);
 		$post = $this->connector->post($this->connector->accountURL, $sign);
 		if(strpos($post['header'], "200 OK") !== false)
@@ -167,35 +167,35 @@ class LEAccount
 			return false;
 		}
 	}
-	
+
     /**
      * Creates new RSA account keys and updates the keys with LetsEncrypt.
-     * 
+     *
      * @return boolean	Returns true if the update is successful, false if not.
      */
 	public function changeAccountKeys()
 	{
-		LEFunctions::RSAgenerateKeys($this->accountKeysDir, 'newPrivate.pem', 'newPublic.pem');
-		$privateKey = openssl_pkey_get_private(file_get_contents($this->accountKeysDir . 'newPrivate.pem'));
+		LEFunctions::RSAgenerateKeys(null, $this->accountKeys['private_key'].'.new', $this->accountKeys['public_key'].'.new');
+		$privateKey = openssl_pkey_get_private(file_get_contents($this->accountKeys['private_key'].'.new'));
 		$details = openssl_pkey_get_details($privateKey);
-		
+
 		$innerPayload = array('account' => $this->accountURL, 'newKey' => array(
 			"kty" => "RSA",
 			"n" => LEFunctions::Base64UrlSafeEncode($details["rsa"]["n"]),
 			"e" => LEFunctions::Base64UrlSafeEncode($details["rsa"]["e"])
 		));
-		$outerPayload = $this->connector->signRequestJWK($innerPayload, $this->connector->keyChange, 'newPrivate.pem');
+		$outerPayload = $this->connector->signRequestJWK($innerPayload, $this->connector->keyChange, $this->accountKeys['private_key'].'.new');
 		$sign = $this->connector->signRequestKid($outerPayload, $this->connector->accountURL, $this->connector->keyChange);
 		$post = $this->connector->post($this->connector->keyChange, $sign);
 		if(strpos($post['header'], "200 OK") !== false)
 		{
 			$this->getLEAccountData();
-			
-			unlink($this->accountKeysDir . 'private.pem');
-			unlink($this->accountKeysDir . 'public.pem');
-			rename($this->accountKeysDir . 'newPrivate.pem', $this->accountKeysDir . 'private.pem');
-			rename($this->accountKeysDir . 'newPublic.pem', $this->accountKeysDir . 'public.pem');
-			
+
+			unlink($this->accountKeys['private_key']);
+			unlink($this->accountKeys['public_key']);
+			rename($this->accountKeys['private_key'].'.new', $this->accountKeys['private_key']);
+			rename($this->accountKeys['public_key'].'.new', $this->accountKeys['public_key']);
+
 			if($this->log >= LECLient::LOG_STATUS) LEFunctions::log('Account keys changed.', 'function changeAccountKey');
 			return true;
 		}
@@ -204,10 +204,10 @@ class LEAccount
 			return false;
 		}
 	}
-	
+
     /**
      * Deactivates the LetsEncrypt account.
-     * 
+     *
      * @return boolean	Returns true if the deactivation is successful, false if not.
      */
 	public function deactivateAccount()

--- a/LEClient/src/LEFunctions.php
+++ b/LEClient/src/LEFunctions.php
@@ -39,7 +39,7 @@ class LEFunctions
     /**
      * Generates a new RSA keypair and saves both keys to a new file.
      *
-     * @param string	$directory		The directory in which to store the new keys.
+     * @param string	$directory		The directory in which to store the new keys. If set to null or empty string - privateKeyFile and publicKeyFile will be treated as absolute paths.
      * @param string	$privateKeyFile	The filename for the private key file.
      * @param string	$publicKeyFile  The filename for the public key file.
      */
@@ -54,8 +54,14 @@ class LEFunctions
 
 		$details = openssl_pkey_get_details($res);
 
-		file_put_contents($directory . $privateKeyFile, $privateKey);
-		file_put_contents($directory . $publicKeyFile, $details['key']);
+		if ($directory !== null && $directory !== '')
+		{
+			$privateKeyFile = $directory.$privateKeyFile;
+			$publicKeyFile = $directory.$publicKeyFile;
+		}
+
+		file_put_contents($privateKeyFile, $privateKey);
+		file_put_contents($publicKeyFile, $details['key']);
 
 		openssl_pkey_free($res);
 	}
@@ -65,7 +71,7 @@ class LEFunctions
     /**
      * Generates a new EC prime256v1 keypair and saves both keys to a new file.
      *
-     * @param string	$directory		The directory in which to store the new keys.
+     * @param string	$directory		The directory in which to store the new keys. If set to null or empty string - privateKeyFile and publicKeyFile will be treated as absolute paths.
      * @param string	$privateKeyFile	The filename for the private key file.
      * @param string	$publicKeyFile  The filename for the public key file.
      */
@@ -82,8 +88,14 @@ class LEFunctions
 
 		$details = openssl_pkey_get_details($res);
 
-		file_put_contents($directory . $privateKeyFile, $privateKey);
-		file_put_contents($directory . $publicKeyFile, $details['key']);
+		if ($directory !== null && $directory !== '')
+		{
+			$privateKeyFile = $directory.$privateKeyFile;
+			$publicKeyFile = $directory.$publicKeyFile;
+		}
+
+		file_put_contents($privateKeyFile, $privateKey);
+		file_put_contents($publicKeyFile, $details['key']);
 
 		openssl_pkey_free($res);
 	}

--- a/LEClient/src/LEOrder.php
+++ b/LEClient/src/LEOrder.php
@@ -471,7 +471,7 @@ class LEOrder
 			subjectAltName = ' . $san . '
 			keyUsage = nonRepudiation, digitalSignature, keyEncipherment');
 
-		$privateKey = openssl_pkey_get_private(file_get_contents($this->certificateKeys['public_key']));
+		$privateKey = openssl_pkey_get_private(file_get_contents($this->certificateKeys['private_key']));
 		$csr = openssl_csr_new($dn, $privateKey, array('config' => $tmpConfPath, 'digest_alg' => 'sha256'));
 		openssl_csr_export ($csr, $csr);
 		return $csr;

--- a/LEClient/src/LEOrder.php
+++ b/LEClient/src/LEOrder.php
@@ -38,9 +38,8 @@ class LEOrder
 {
 	private $connector;
 
-	private $keysDir;
 	private $basename;
-	private $orderDir;
+	private $certificateKeys;
 	private $orderURL;
 	private $keyType;
 
@@ -63,25 +62,25 @@ class LEOrder
      *
      * @param LEConnector	$connector	The LetsEncrypt Connector instance to use for HTTP requests.
      * @param int 			$log 		The level of logging. Defaults to no logging. LOG_OFF, LOG_STATUS, LOG_DEBUG accepted.
-     * @param string 		$keysDir 	The main directory in which all keys (and certificates), including account keys, are stored.
+     * @param array 		$certificateKeys 	Array containing location of certificate keys files.
      * @param string 		$basename 	The base name for the order. Preferable the top domain (example.org). Will be the directory in which the keys are stored. Used for the CommonName in the certificate as well.
      * @param array 		$domains 	The array of strings containing the domain names on the certificate.
 	 * @param string 		$keyType 	Type of the key we want to use for certificate. Supported values are "rsa" (default) and "ec".
      * @param string 		$notBefore 	A date string formatted like 0000-00-00T00:00:00Z (yyyy-mm-dd hh:mm:ss) at which the certificate becomes valid.
      * @param string 		$notAfter 	A date string formatted like 0000-00-00T00:00:00Z (yyyy-mm-dd hh:mm:ss) until which the certificate is valid.
      */
-	public function __construct($connector, $log, $keysDir, $basename, $domains, $keyType, $notBefore, $notAfter)
+	public function __construct($connector, $log, $certificateKeys, $basename, $domains, $keyType, $notBefore, $notAfter)
 	{
 		$this->connector = $connector;
 		$this->basename = $basename;
 		$this->log = $log;
 		$this->keyType = $keyType;
 
-		$this->orderDir = $keysDir . $this->basename . '/';
+		$this->certificateKeys = $certificateKeys;
 
-		if(file_exists($this->orderDir) AND file_exists($this->orderDir . 'private.pem') AND file_exists($this->orderDir . 'public.pem') AND file_exists($this->orderDir . 'order'))
+		if(file_exists($this->certificateKeys['private_key']) AND file_exists($this->certificateKeys['order']) AND file_exists($this->certificateKeys['public_key']))
 		{
-			$this->orderURL = file_get_contents($this->orderDir . '/order');
+			$this->orderURL = file_get_contents($this->certificateKeys['order']);
 			if (filter_var($this->orderURL, FILTER_VALIDATE_URL))
 			{
 				$get = $this->connector->get($this->orderURL);
@@ -91,9 +90,11 @@ class LEOrder
 					$diff = array_merge(array_diff($orderdomains, $domains), array_diff($domains, $orderdomains));
 					if(!empty($diff))
 					{
-						$newDir = $keysDir . $this->basename . '-backup-' . date('dmYHis') . '/';
-						rename($this->orderDir, $newDir);
-						if($this->log >= LECLient::LOG_STATUS) LEFunctions::log('Domains do not match order data. Changing directory to ' . $newDir . ' and creating new order.', 'function LEOrder __construct');
+						foreach ($this->certificateKeys as $file)
+						{
+							if (is_file($file)) rename($file, $file.'.old');
+						}
+						if($this->log >= LECLient::LOG_STATUS) LEFunctions::log('Domains do not match order data. Renaming current files and creating new order.', 'function LEOrder __construct');
 						$this->createOrder($domains, $notBefore, $notAfter, $keyType);
 					}
 					else
@@ -109,15 +110,23 @@ class LEOrder
 				}
 				else
 				{
+					foreach ($this->certificateKeys as $file)
+					{
+						if (is_file($file)) unlink($file);
+					}
 					if($this->log >= LECLient::LOG_STATUS) LEFunctions::log('Order data for \'' . $this->basename . '\' invalid. Deleting order data and creating new order.', 'function LEOrder __construct');
-					unlink($this->orderDir);
 					$this->createOrder($domains, $notBefore, $notAfter);
 				}
 			}
 			else
 			{
+
+				foreach ($this->certificateKeys as $file)
+				{
+					if (is_file($file)) unlink($file);
+				}
 				if($this->log >= LECLient::LOG_STATUS) LEFunctions::log('Order data for \'' . $this->basename . '\' invalid. Deleting order data and creating new order.', 'function LEOrder __construct');
-				unlink($this->orderDir);
+
 				$this->createOrder($domains, $notBefore, $notAfter);
 			}
 		}
@@ -139,7 +148,6 @@ class LEOrder
 	{
 		if(preg_match('~(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z|^$)~', $notBefore) AND preg_match('~(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z|^$)~', $notAfter))
 		{
-			mkdir($this->orderDir, 0777, true);
 
 			$dns = array();
 			foreach($domains as $domain)
@@ -155,15 +163,15 @@ class LEOrder
 			{
 				if(preg_match('~Location: (\S+)~i', $post['header'], $matches))
 				{
-					$this->orderURL = trim($matches[1])
-					file_put_contents($this->orderDir . 'order', $this->orderURL);
-					if ($this->keyType == "rsa") 
+					$this->orderURL = trim($matches[1]);
+					file_put_contents($this->certificateKeys['order'], $this->orderURL);
+					if ($this->keyType == "rsa")
 					{
-						LEFunctions::RSAgenerateKeys($this->orderDir); 
+						LEFunctions::RSAgenerateKeys(null, $this->certificateKeys['private_key'], $this->certificateKeys['public_key']);
 					}
-					elseif ($this->keyType == "ec") 
-					{ 
-						LEFunctions::ECgenerateKeys($this->orderDir); 
+					elseif ($this->keyType == "ec")
+					{
+						LEFunctions::ECgenerateKeys(null, $this->certificateKeys['private_key'], $this->certificateKeys['public_key']);
 					}
 					else
 					{
@@ -267,7 +275,7 @@ class LEOrder
 	{
 		$authorizations = array();
 
-		$privateKey = openssl_pkey_get_private(file_get_contents($this->connector->accountKeysDir . 'private.pem'));
+		$privateKey = openssl_pkey_get_private(file_get_contents($this->connector->accountKeys['private_key']));
 		$details = openssl_pkey_get_details($privateKey);
 
 		$header = array(
@@ -314,7 +322,7 @@ class LEOrder
      */
 	public function verifyPendingOrderAuthorization($identifier, $type)
 	{
-		$privateKey = openssl_pkey_get_private(file_get_contents($this->connector->accountKeysDir . 'private.pem'));
+		$privateKey = openssl_pkey_get_private(file_get_contents($this->connector->accountKeys['private_key']));
 		$details = openssl_pkey_get_details($privateKey);
 
 		$header = array(
@@ -463,7 +471,7 @@ class LEOrder
 			subjectAltName = ' . $san . '
 			keyUsage = nonRepudiation, digitalSignature, keyEncipherment');
 
-		$privateKey = openssl_pkey_get_private(file_get_contents($this->orderDir . '/private.pem'));
+		$privateKey = openssl_pkey_get_private(file_get_contents($this->certificateKeys['public_key']));
 		$csr = openssl_csr_new($dn, $privateKey, array('config' => $tmpConfPath, 'digest_alg' => 'sha256'));
 		openssl_csr_export ($csr, $csr);
 		return $csr;
@@ -545,15 +553,19 @@ class LEOrder
 			{
 				if(preg_match_all('~(-----BEGIN\sCERTIFICATE-----[\s\S]+?-----END\sCERTIFICATE-----)~i', $get['body'], $matches))
 				{
-					file_put_contents($this->orderDir . '/certificate.crt',  $matches[0][0]);
-					if(count($matches[0]) > 1)
+					if (isset($this->certificateKeys['certificate'])) file_put_contents($this->certificateKeys['certificate'],  $matches[0][0]);
+
+					if(count($matches[0]) > 1 && isset($this->certificateKeys['fullchain_certificate']))
 					{
+						$fullchain = $matches[0][0]."\n";
 						for($i=1;$i<count($matches[0]);$i++)
 						{
-							file_put_contents($this->orderDir . '/chain' . $i . '.crt',  $matches[0][$i]);
+							$fullchain .= $matches[0][$i]."\n";
+
 						}
+						file_put_contents(trim($this->certificateKeys['fullchain_certificate']), $fullchain);
 					}
-					if($this->log >= LECLient::LOG_STATUS) LEFunctions::log('Certificate for \'' . $this->basename . '\' stored in \'' . $this->orderDir . '\'.', 'function getCertificate');
+					if($this->log >= LECLient::LOG_STATUS) LEFunctions::log('Certificate for \'' . $this->basename . '\' saved', 'function getCertificate');
 					return true;
 				}
 				else
@@ -585,13 +597,17 @@ class LEOrder
 	{
 		if($this->status == 'valid')
 		{
-			if(file_exists($this->orderDir . 'certificate.crt') && file_exists($this->orderDir . 'private.pem'))
+			if (isset($this->certificateKeys['certificate'])) $certFile = $this->certificateKeys['certificate'];
+			elseif (isset($this->certificateKeys['fullchain_certificate']))  $certFile = $this->certificateKeys['fullchain_certificate'];
+			else throw new \RuntimeException('certificateKeys[certificate] or certificateKeys[fullchain_certificate] required');
+
+			if(file_exists($certFile) && file_exists($this->certificateKeys['private_key']))
 			{
-				$certificate = file_get_contents($this->orderDir . 'certificate.crt');
+				$certificate = file_get_contents($this->certificateKeys['certificate']);
 				preg_match('~-----BEGIN\sCERTIFICATE-----(.*)-----END\sCERTIFICATE-----~s', $certificate, $matches);
 				$certificate = trim(LEFunctions::Base64UrlSafeEncode(base64_decode(trim($matches[1]))));
 
-				$sign = $this->connector->signRequestJWK(array('certificate' => $certificate, 'reason' => $reason), $this->connector->revokeCert, 'private.pem', $this->orderDir);
+				$sign = $this->connector->signRequestJWK(array('certificate' => $certificate, 'reason' => $reason), $this->connector->revokeCert);
 				$post = $this->connector->post($this->connector->revokeCert, $sign);
 				if(strpos($post['header'], "200 OK") !== false)
 				{


### PR DESCRIPTION
This commit introduce more flexible way to set account and certificates paths without breaking current scheme (at LEClient.php level). 

My goal is to make LEClient more usable in shared hosting environments (from hosting company perspective) where paths to account keys/certificates might be different or even hardcoded in management software.

Use case scenarios: 

- LE is recommending to use single account for large hosting providers.
- For every domain there may be separate RSA and ECDSA certificates, served simultaneously by webserver.

With this changes it's possible to set custom paths for every file:

**$accountKeys** (replacement for $accountKeysDir) would still accept simple path (string) OR array containing individual paths: 

`
$accountKeys = array(
	'private_key' => 'example/path/private.pem',
	'public_key' => 'example/path/private.pem'
);
`

Both private_key and public_key would be required.


Scheme of **$certificateKeys** (replacement for $keysDir - also accepts string or array):

`
$certificateKeys = array(
	'private_key' => '/home/user/ssl/ssl.key',
	'public_key' => '/home/user/ssl/ssl.pub.key',
	'order' => '/home/user/ssl/xxx.com_ecc_order',
	'fullchain_certificate' => '/home/user/ssl/ssl.full.crt',
	'certificate' => '/home/user/ssl/ssl.crt'
);
`

Required params are: private_key and at least one of the following: fullchain_certificate, certificate. 
order and public_key are optional, with default values `dirname(private_key)/order` and `dirname(private_key)/public.pem`.



My changes include refactor of every class to use this new format internally and conversion layer (in case user decides to use default scheme) located in constructor od LEClient class.


