### PR TITLE
Fixed Content-Type

### DIFF
--- a/LEClient/src/LEConnector.php
+++ b/LEClient/src/LEConnector.php
@@ -102,7 +102,7 @@ class LEConnector
 	{
 		if($this->accountDeactivated) throw new \RuntimeException('The account was deactivated. No further requests can be made.');
 
-		$headers = array('Accept: application/json', 'Content-Type: application/json');
+		$headers = array('Accept: application/json', 'Content-Type: application/jose+json');
 		$requestURL = preg_match('~^http~', $URL) ? $URL : $this->baseURL . $URL;
         $handle = curl_init();
         curl_setopt($handle, CURLOPT_URL, $requestURL);


### PR DESCRIPTION
POST JWS Content Type from March 29th 2018 must be "application/jose+json" for ACMEv2:

https://community.letsencrypt.org/t/jws-post-content-type-header-enforcement/55055