### PR TITLE
Save chain separately from fullchain, Fix error with agreement not being set, Move CertificateKeys into a public function

### DIFF
--- a/LEClient/LEClient.php
+++ b/LEClient/LEClient.php
@@ -90,44 +90,7 @@ class LEClient
 		if (is_array($certificateKeys) && is_string($accountKeys)) throw new \RuntimeException('When certificateKeys is array, accountKeys must be array too.');
 		elseif (is_array($accountKeys) && is_string($certificateKeys)) throw new \RuntimeException('When accountKeys is array, certificateKeys must be array too.');
 
-		if (is_string($certificateKeys))
-		{
-			$certificateKeysDir = $certificateKeys;
-
-			if(!file_exists($certificateKeys))
-			{
-				mkdir($certificateKeys, 0777, true);
-				LEFunctions::createhtaccess($certificateKeys);
-			}
-
-			$this->certificateKeys = array(
-				"public_key" => $certificateKeys.'/public.pem',
-				"private_key" => $certificateKeys.'/private.pem',
-				"certificate" => $certificateKeys.'/certificate.crt',
-				"fullchain_certificate" => $certificateKeys.'/fullchain.crt',
-				"chain" => $certificateKeys.'/chain.pem',
-				"order" => $certificateKeys.'/order'
-			);
-		}
-		elseif (is_array($certificateKeys))
-		{
-			if (!isset($certificateKeys['certificate']) && !isset($certificateKeys['fullchain_certificate'])) throw new \RuntimeException('certificateKeys[certificate] or certificateKeys[fullchain_certificate] file path must be set.');
-			if (!isset($certificateKeys['private_key'])) throw new \RuntimeException('certificateKeys[private_key] file path must be set.');
-			if (!isset($certificateKeys['order'])) $certificateKeys['order'] = dirname($certificateKeys['private_key']).'/order';
-			if (!isset($certificateKeys['public_key'])) $certificateKeys['public_key'] = dirname($certificateKeys['private_key']).'/public.pem';
-			if (!isset($certificateKeys['chain'])) { $certificateKeys['chain'] = dirname($certificateKeys['fullchain_certificate']) . '/chain.pem'; }
-
-			foreach ($certificateKeys as $param => $file) {
-				$parentDir = dirname($file);
-				if (!is_dir($parentDir)) throw new \RuntimeException($parentDir.' directory not found.');
-			}
-
-			$this->certificateKeys = $certificateKeys;
-		}
-		else
-		{
-			throw new \RuntimeException('certificateKeys must be string or array.');
-		}
+		$this->setCertificateKeys($certificateKeys);
 
 		if (is_string($accountKeys))
 		{
@@ -177,6 +140,57 @@ class LEClient
 	{
 		return $this->account;
 	}
+
+    /**
+     * Updates the CertificateKeys, useful for changing the domain information we want to place an order on while keeping the same account details
+     *
+     * @param string|array 	$certificateKeys 		The main directory in which all keys (and certificates), including account keys, are stored. Defaults to 'keys/'. (optional)
+     * 						$certificateKeys 		Optional array containing location of all certificate files. Required paths are public_key, private_key, order and certificate/fullchain_certificate (you can use both or only one of them)
+     *
+     * @return LEClient	The LetsEncrypt LEClient instance
+     */
+    public function setCertificateKeys($certificateKeys)
+    {
+        if (is_string($certificateKeys))
+        {
+            $certificateKeysDir = $certificateKeys;
+
+            if(!file_exists($certificateKeys))
+            {
+                mkdir($certificateKeys, 0777, true);
+                LEFunctions::createhtaccess($certificateKeys);
+            }
+
+            $this->certificateKeys = array(
+                "public_key" => $certificateKeys.'/public.pem',
+                "private_key" => $certificateKeys.'/private.pem',
+                "certificate" => $certificateKeys.'/certificate.crt',
+                "fullchain_certificate" => $certificateKeys.'/fullchain.crt',
+                "chain" => $certificateKeys.'/chain.pem',
+                "order" => $certificateKeys.'/order'
+            );
+        }
+	    elseif (is_array($certificateKeys))
+        {
+            if (!isset($certificateKeys['certificate']) && !isset($certificateKeys['fullchain_certificate'])) throw new \RuntimeException('certificateKeys[certificate] or certificateKeys[fullchain_certificate] file path must be set.');
+            if (!isset($certificateKeys['private_key'])) throw new \RuntimeException('certificateKeys[private_key] file path must be set.');
+            if (!isset($certificateKeys['order'])) $certificateKeys['order'] = dirname($certificateKeys['private_key']).'/order';
+            if (!isset($certificateKeys['public_key'])) $certificateKeys['public_key'] = dirname($certificateKeys['private_key']).'/public.pem';
+            if (!isset($certificateKeys['chain'])) { $certificateKeys['chain'] = dirname($certificateKeys['fullchain_certificate']) . '/chain.pem'; }
+
+            foreach ($certificateKeys as $param => $file) {
+                $parentDir = dirname($file);
+                if (!is_dir($parentDir)) throw new \RuntimeException($parentDir.' directory not found.');
+            }
+
+            $this->certificateKeys = $certificateKeys;
+        }
+        else
+        {
+            throw new \RuntimeException('certificateKeys must be string or array.');
+        }
+        return $this;
+    }
 
     /**
      * Returns a LetsEncrypt order. If an order exists, this one is returned. If not, a new order is created and returned.

--- a/LEClient/LEClient.php
+++ b/LEClient/LEClient.php
@@ -105,7 +105,7 @@ class LEClient
 				"private_key" => $certificateKeys.'/private.pem',
 				"certificate" => $certificateKeys.'/certificate.crt',
 				"fullchain_certificate" => $certificateKeys.'/fullchain.crt',
-				"chain" => $certificateKeys.'/chain.crt',
+				"chain" => $certificateKeys.'/chain.pem',
 				"order" => $certificateKeys.'/order'
 			);
 		}

--- a/LEClient/LEClient.php
+++ b/LEClient/LEClient.php
@@ -105,6 +105,7 @@ class LEClient
 				"private_key" => $certificateKeys.'/private.pem',
 				"certificate" => $certificateKeys.'/certificate.crt',
 				"fullchain_certificate" => $certificateKeys.'/fullchain.crt',
+				"chain" => $certificateKeys.'/chain.crt',
 				"order" => $certificateKeys.'/order'
 			);
 		}
@@ -114,6 +115,7 @@ class LEClient
 			if (!isset($certificateKeys['private_key'])) throw new \RuntimeException('certificateKeys[private_key] file path must be set.');
 			if (!isset($certificateKeys['order'])) $certificateKeys['order'] = dirname($certificateKeys['private_key']).'/order';
 			if (!isset($certificateKeys['public_key'])) $certificateKeys['public_key'] = dirname($certificateKeys['private_key']).'/public.pem';
+			if (!isset($certificateKeys['chain'])) { $certificateKeys['chain'] = dirname($certificateKeys['fullchain_certificate']) . '/chain.pem'; }
 
 			foreach ($certificateKeys as $param => $file) {
 				$parentDir = dirname($file);

--- a/LEClient/src/LEAccount.php
+++ b/LEClient/src/LEAccount.php
@@ -126,7 +126,7 @@ class LEAccount
 			$this->id = $post['body']['id'];
 			$this->key = $post['body']['key'];
 			$this->contact = $post['body']['contact'];
-			$this->agreement = $post['body']['agreement'];
+			//$this->agreement = $post['body']['agreement'];
 			$this->initialIp = $post['body']['initialIp'];
 			$this->createdAt = $post['body']['createdAt'];
 			$this->status = $post['body']['status'];

--- a/LEClient/src/LEOrder.php
+++ b/LEClient/src/LEOrder.php
@@ -580,13 +580,29 @@ class LEOrder
 
 					if(count($matches[0]) > 1 && isset($this->certificateKeys['fullchain_certificate']))
 					{
-						$fullchain = $matches[0][0]."\n";
+						$chain = NULL;
+						$fullchain = NULL;
+						if (isset($this->certificateKeys['chain'])) {
+							$chain = "\n";
+						}
+						if (isset($this->certificateKeys['fullchain_certificate'])) {
+							$fullchain = $matches[0][0]."\n";
+						}
 						for($i=1;$i<count($matches[0]);$i++)
 						{
-							$fullchain .= $matches[0][$i]."\n";
-
+							if (isset($this->certificateKeys['chain'])) {
+								$chain .= $matches[0][$i]."\n";
+							}
+							if (isset($this->certificateKeys['fullchain_certificate'])) {
+								$fullchain .= $matches[0][$i] . "\n";
+							}
 						}
-						file_put_contents(trim($this->certificateKeys['fullchain_certificate']), $fullchain);
+						if (!empty($fullchain)) {
+							file_put_contents(trim($this->certificateKeys['fullchain_certificate']), $fullchain);
+						}
+						if (!empty($chain)) {
+							file_put_contents(trim($this->certificateKeys['chain']), $chain);
+						}
 					}
 					if($this->log >= LECLient::LOG_STATUS) LEFunctions::log('Certificate for \'' . $this->basename . '\' saved', 'function getCertificate');
 					return true;


### PR DESCRIPTION
Here are a few changes I made to improve LEClient:

1) I needed the intermediate cert saved in a chain.pem to use in other things
2) Agreement was giving an error cause it wasn't found in the response, so it was commented out as it wasn't in use anyway
3) Moved CertificateKeys into a public function, which will allow me to change the cert it's generating without reconstructing the client for every domain, removing unneeded requests to LE Servers for the account.