### PR TITLE
Fixed bugs and added key length into CSR config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.idea
 keys/*

--- a/LEClient/src/LEAccount.php
+++ b/LEClient/src/LEAccount.php
@@ -126,7 +126,7 @@ class LEAccount
 			$this->id = $post['body']['id'];
 			$this->key = $post['body']['key'];
 			$this->contact = $post['body']['contact'];
-			$this->agreement = $post['body']['agreement'];
+			$this->agreement = isset($post['body']['agreement']) ? $post['body']['agreement'] : '';
 			$this->initialIp = $post['body']['initialIp'];
 			$this->createdAt = $post['body']['createdAt'];
 			$this->status = $post['body']['status'];
@@ -155,7 +155,7 @@ class LEAccount
 			$this->id = $post['body']['id'];
 			$this->key = $post['body']['key'];
 			$this->contact = $post['body']['contact'];
-			$this->agreement = $post['body']['agreement'];
+            $this->agreement = isset($post['body']['agreement']) ? $post['body']['agreement'] : '';
 			$this->initialIp = $post['body']['initialIp'];
 			$this->createdAt = $post['body']['createdAt'];
 			$this->status = $post['body']['status'];

--- a/LEClient/src/LEAccount.php
+++ b/LEClient/src/LEAccount.php
@@ -155,7 +155,7 @@ class LEAccount
 			$this->id = $post['body']['id'];
 			$this->key = $post['body']['key'];
 			$this->contact = $post['body']['contact'];
-            $this->agreement = isset($post['body']['agreement']) ? $post['body']['agreement'] : '';
+			$this->agreement = isset($post['body']['agreement']) ? $post['body']['agreement'] : '';
 			$this->initialIp = $post['body']['initialIp'];
 			$this->createdAt = $post['body']['createdAt'];
 			$this->status = $post['body']['status'];

--- a/LEClient/src/LEFunctions.php
+++ b/LEClient/src/LEFunctions.php
@@ -193,7 +193,8 @@ class LEFunctions
         curl_setopt($handle, CURLOPT_URL, $requestURL);
         curl_setopt($handle, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($handle, CURLOPT_FOLLOWLOCATION, true);
-        $response = curl_exec($handle);
+        $response = trim(curl_exec($handle));
+
 		return (!empty($response) && $response == $keyAuthorization);
 	}
 

--- a/LEClient/src/LEOrder.php
+++ b/LEClient/src/LEOrder.php
@@ -509,7 +509,7 @@ class LEOrder
      */
 	public function finalizeOrder($csr = '')
 	{
-		if($this->status == 'pending')
+		if($this->status == 'pending' || $this->status == 'ready')
 		{
 			if($this->allAuthorizationsValid())
 			{

--- a/LEClient/src/LEOrder.php
+++ b/LEClient/src/LEOrder.php
@@ -483,7 +483,7 @@ class LEOrder
             'HOME = .
 			RANDFILE = $ENV::HOME/.rnd
 			[ req ]
-			default_bits = 4096
+			default_bits = ' . $this->keySize . '
 			default_keyfile = privkey.pem
 			distinguished_name = req_distinguished_name
 			req_extensions = v3_req


### PR DESCRIPTION
I am looking to provision certificates that will be used by Amazon CloudFront. CloudFront has a limitation on private key length of 2048 bits. I added $this->keyLength into the CSR config in LEOrder.

While testing, I found some bugs:

1. I was not able to get past the local HTTP verification because the LEFunctions::checkHTTPChallenge() helper was not trimming a newline character from the cURL response.
2. The cURL response in LEAccount::getLEAccountData() does not contain the key 'agreement'. I made this optional.
3. The ACME v2 order status of 'ready' (https://community.letsencrypt.org/t/acmev2-order-ready-status/62866) is not currently supported. I've added a check for 'ready' status in the LEOrder::finalizeOrder() method.

