### PR TITLE
PSR-4 autoloading support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
-.idea
-keys/*
+.idea/
+keys/
+vendor/
+composer.lock

--- a/README.md
+++ b/README.md
@@ -23,10 +23,12 @@ This client also depends on cURL and OpenSSL.
 
 ### Installing
 
-Download and install the LEClient folder and examples wherever you want to install it. You can include the library by adding the following:
-```php
-require_once('LEClient/LEClient.php');
+Using composer:
+```bash
+composer require yourivw/leclient
 ```
+
+Although it is possible to add this to your own autoloader, it's not recommended as you'll have no control of the dependencies. If you haven't used composer before, I strongly recommend you check it out at [https://getcomposer.org](https://getcomposer.org).
 
 It is advisable to cut the script some slack regarding execution time by setting a higher maximum time. There are several ways to do so. One it to add the following to the top of the page:
 ```php
@@ -41,6 +43,8 @@ The basic functions and its necessary arguments are shown here. An extended desc
 
 Initiating the client:
 ```php
+use LEClient\LEClient;
+
 $client = new LEClient($email);                               // Initiating a basic LEClient with an array of string e-mail address(es).
 $client = new LEClient($email, true);                         // Initiating a LECLient and use the LetsEncrypt staging URL.
 $client = new LEClient($email, true, LEClient::LOG_STATUS);   // Initiating a LEClient and log status messages (LOG_DEBUG for full debugging).
@@ -84,6 +88,8 @@ $revoke     = $order->revokeCertificate($reason);                           // R
 
 Supportive functions:
 ```php
+use LEClient\LEFunctions;
+
 LEFunctions::RSAGenerateKeys($directory, $privateKeyFile, $publicKeyFile);  // Generate a RSA keypair in the given directory. Variables privateKeyFile and publicKeyFile are optional and have default values private.pem and public.pem.
 LEFunctions::ECGenerateKeys($directory, $privateKeyFile, $publicKeyFile);  	// Generate a EC keypair in the given directory (PHP 7.1+ required). Variables privateKeyFile and publicKeyFile are optional and have default values private.pem and public.pem.
 LEFunctions::Base64UrlSafeEncode($input);                                   // Encode the input string as a base64 URL safe string.
@@ -102,6 +108,8 @@ LetsEncrypt (ACME) performs authorizations on the domains you want to include on
 
 For this example, we assume there is one domain left to verify.
 ```php
+use LEClient\LEOrder;
+
 $pending = $order->getPendingAuthorizations(LEOrder::CHALLENGE_TYPE_HTTP);
 ```
 This returns an array:
@@ -172,4 +180,4 @@ When the client created the keys directory for the first time, it will store a .
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for details.
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/composer.json
+++ b/composer.json
@@ -5,5 +5,10 @@
     "license": "MIT",
     "require": {
         "php": ">=5.2"
+    },
+    "autoload": {
+        "psr-4": {
+            "LEClient\\": "src/"
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "PHP LetsEncrypt client library for ACME v2",
     "license": "MIT",
     "require": {
-        "php": ">=5.2"
+        "php": ">=7.1"
     },
     "autoload": {
         "psr-4": {

--- a/examples/dns_finish.php
+++ b/examples/dns_finish.php
@@ -1,8 +1,12 @@
 <?php
-//Sets the maximum execution time to two minutes, to be sure.
+// Sets the maximum execution time to two minutes, to be sure.
 ini_set('max_execution_time', 120);
-// Including the LetsEncrypt Client.
-require_once('LEClient/LEClient.php');
+// Including the autoloader.
+include __DIR__.'/../vendor/autoload.php';
+
+// Importing the classes.
+use LEClient\LEClient;
+use LEClient\LEOrder;
 
 // Listing the contact information in case a new account has to be created.
 $email = array('info@example.org');

--- a/examples/dns_init.php
+++ b/examples/dns_init.php
@@ -1,8 +1,12 @@
 <?php
-//Sets the maximum execution time to two minutes, to be sure.
+// Sets the maximum execution time to two minutes, to be sure.
 ini_set('max_execution_time', 120);
-// Including the LetsEncrypt Client.
-require_once('LEClient/LEClient.php');
+// Including the autoloader.
+include __DIR__.'/../vendor/autoload.php';
+
+// Importing the classes.
+use LEClient\LEClient;
+use LEClient\LEOrder;
 
 // Listing the contact information in case a new account has to be created.
 $email = array('info@example.org');

--- a/examples/http.php
+++ b/examples/http.php
@@ -1,8 +1,12 @@
 <?php
-//Sets the maximum execution time to two minutes, to be sure.
+// Sets the maximum execution time to two minutes, to be sure.
 ini_set('max_execution_time', 120);
-// Including the LetsEncrypt Client.
-require_once('LEClient/LEClient.php');
+// Including the autoloader.
+include __DIR__.'/../vendor/autoload.php';
+
+// Importing the classes.
+use LEClient\LEClient;
+use LEClient\LEOrder;
 
 // Listing the contact information in case a new account has to be created.
 $email = array('info@example.org');

--- a/src/LEAccount.php
+++ b/src/LEAccount.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace LEClient;
+
 /**
  * LetsEncrypt Account class, containing the functions and data associated with a LetsEncrypt account.
  *

--- a/src/LEAuthorization.php
+++ b/src/LEAuthorization.php
@@ -91,7 +91,7 @@ class LEAuthorization
 		}
 		else
 		{
-			if($this->log >= LECLient::LOG_STATUS) LEFunctions::log('Cannot find authorization \'' . $authorizationURL . '\'.', 'function updateData');
+			if($this->log >= LECLient::LOG_STATUS) LEFunctions::log('Cannot find authorization \'' . $this->authorizationURL . '\'.', 'function updateData');
 		}
 	}
 	

--- a/src/LEAuthorization.php
+++ b/src/LEAuthorization.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace LEClient;
+
 /**
  * LetsEncrypt Authorization class, getting LetsEncrypt authorization data associated with a LetsEncrypt Order instance.
  *

--- a/src/LEClient.php
+++ b/src/LEClient.php
@@ -1,13 +1,6 @@
 <?php
 
-/**
- * Load the dependencies for the LetsEncrypt Client
- */
-require_once('src/LEConnector.php');
-require_once('src/LEAccount.php');
-require_once('src/LEOrder.php');
-require_once('src/LEAuthorization.php');
-require_once('src/LEFunctions.php');
+namespace LEClient;
 
 /**
  * Main LetsEncrypt Client class, works as a framework for the LEConnector, LEAccount, LEOrder and LEAuthorization classes.

--- a/src/LEConnector.php
+++ b/src/LEConnector.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace LEClient;
+
 /**
  * LetsEncrypt Connector class, containing the functions necessary to sign with JSON Web Key and Key ID, and perform GET, POST and HEAD requests.
  *

--- a/src/LEFunctions.php
+++ b/src/LEFunctions.php
@@ -1,5 +1,9 @@
 <?php
 
+namespace LEClient;
+
+use Exception;
+
 /**
  * LetsEncrypt Functions class, supplying the LetsEncrypt Client with supportive functions.
  *

--- a/src/LEOrder.php
+++ b/src/LEOrder.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace LEClient;
+
 /**
  * LetsEncrypt Order class, containing the functions and data associated with a specific LetsEncrypt order.
  *


### PR DESCRIPTION
To improve the usage of this wonderful library, I've added autoloading support of the classes compliant with the PSR-4 standard. This is needed because currently it's a hassle to include the classes by adding:

```php
require_once base_path().'/vendor/yourivw/leclient/LEClient.php';
```

in each and every file that uses the client library. Whereas, composer can handle it just by installing the package, call the class and voila!

Major changes in this PR includes:
- Set the minimum PHP version to 7.1 as per the README.
- Added the `\LEClient` namespace.
- Moved all the examples to `examples/` directory.
- Bug fix related to a missing variable. Reference: https://github.com/yourivw/LEClient/commit/0438ad408491b0acca5427d8f93076b3dcdd7958.