### PR TITLE
fix missing index id in LEAccount

### DIFF
--- a/src/LEAccount.php
+++ b/src/LEAccount.php
@@ -129,7 +129,7 @@ class LEAccount
 		$post = $this->connector->post($this->connector->accountURL, $sign);
 		if(strpos($post['header'], "200 OK") !== false)
 		{
-			$this->id = $post['body']['id'];
+			$this->id = isset($post['body']['id']) ? $post['body']['id'] : '';
 			$this->key = $post['body']['key'];
 			$this->contact = $post['body']['contact'];
 			$this->agreement = isset($post['body']['agreement']) ? $post['body']['agreement'] : '';


### PR DESCRIPTION
ACME protocol does not require 'id' field for [Account Object](https://tools.ietf.org/html/draft-ietf-acme-acme-15#section-7.1.2).
Requiring it causes unhandled exception in some cases.