### PR TITLE
Multiple improvements/fixes: apply PSR2, improve readability, fix unused property.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This client was developed with the use of the LetsEncrypt staging server for ver
 
 ## Getting Started
 
-These instructions will get you started with this client library. Is you have any questions or find any problems, feel free to open an issue and I'll try to have a look at it.
+These instructions will get you started with this client library. If you have any questions or find any problems, feel free to open an issue and I'll try to have a look at it.
 
 Also have a look at the [LetsEncrypt documentation](https://letsencrypt.org/docs/) for more information and documentation on LetsEncrypt and ACME.
 

--- a/src/LEAccount.php
+++ b/src/LEAccount.php
@@ -97,7 +97,7 @@ class LEAccount
             return empty($addr) ? '' : (strpos($addr, 'mailto') === false ? 'mailto:' . $addr : $addr);
         }, $email);
 
-        $sign = $this->connector->signRequestJWK(['contact' => $contact, 'termsOfServiceAgreed' => true], $this->connector->newAccount);
+        $sign = $this->connector->signRequestJWK(array('contact' => $contact, 'termsOfServiceAgreed' => true), $this->connector->newAccount);
         $post = $this->connector->post($this->connector->newAccount, $sign);
 
         if (strpos($post['header'], "201 Created") !== false) {
@@ -116,7 +116,7 @@ class LEAccount
      */
     private function getLEAccount()
     {
-        $sign = $this->connector->signRequestJWK(['onlyReturnExisting' => true], $this->connector->newAccount);
+        $sign = $this->connector->signRequestJWK(array('onlyReturnExisting' => true), $this->connector->newAccount);
         $post = $this->connector->post($this->connector->newAccount, $sign);
 
         if (strpos($post['header'], "200 OK") !== false) {
@@ -133,7 +133,7 @@ class LEAccount
      */
     private function getLEAccountData()
     {
-        $sign = $this->connector->signRequestKid(['' => ''], $this->connector->accountURL, $this->connector->accountURL);
+        $sign = $this->connector->signRequestKid(array('' => ''), $this->connector->accountURL, $this->connector->accountURL);
         $post = $this->connector->post($this->connector->accountURL, $sign);
 
         if (strpos($post['header'], "200 OK") !== false) {
@@ -162,7 +162,7 @@ class LEAccount
             return empty($addr) ? '' : (strpos($addr, 'mailto') === false ? 'mailto:' . $addr : $addr);
         }, $email);
 
-        $sign = $this->connector->signRequestKid(['contact' => $contact], $this->connector->accountURL, $this->connector->accountURL);
+        $sign = $this->connector->signRequestKid(array('contact' => $contact), $this->connector->accountURL, $this->connector->accountURL);
         $post = $this->connector->post($this->connector->accountURL, $sign);
 
         if (strpos($post['header'], "200 OK") !== false) {
@@ -198,11 +198,11 @@ class LEAccount
         $oldPrivateKey = openssl_pkey_get_private(file_get_contents($this->accountKeys['private_key']));
         $oldDetails = openssl_pkey_get_details($oldPrivateKey);
 
-        $innerPayload = ['account' => $this->connector->accountURL, 'oldKey' => [
+        $innerPayload = array('account' => $this->connector->accountURL, 'oldKey' => array(
             "kty" => "RSA",
             "n" => LEFunctions::Base64UrlSafeEncode($oldDetails["rsa"]["n"]),
             "e" => LEFunctions::Base64UrlSafeEncode($oldDetails["rsa"]["e"])
-        ]];
+        ));
 
         $outerPayload = $this->connector->signRequestJWK($innerPayload, $this->connector->keyChange, $this->accountKeys['private_key'].'.new');
         $sign = $this->connector->signRequestKid($outerPayload, $this->connector->accountURL, $this->connector->keyChange);
@@ -235,7 +235,7 @@ class LEAccount
      */
     public function deactivateAccount()
     {
-        $sign = $this->connector->signRequestKid(['status' => 'deactivated'], $this->connector->accountURL, $this->connector->accountURL);
+        $sign = $this->connector->signRequestKid(array('status' => 'deactivated'), $this->connector->accountURL, $this->connector->accountURL);
         $post = $this->connector->post($this->connector->accountURL, $sign);
 
         if (strpos($post['header'], "200 OK") !== false) {

--- a/src/LEAccount.php
+++ b/src/LEAccount.php
@@ -37,18 +37,18 @@ namespace LEClient;
  */
 class LEAccount
 {
-	private $connector;
-	private $accountKeys;
+    private $connector;
+    private $accountKeys;
 
-	public $id;
-	public $key;
-	public $contact;
-	public $agreement;
-	public $initialIp;
-	public $createdAt;
-	public $status;
+    public $id;
+    public $key;
+    public $contact;
+    public $agreement;
+    public $initialIp;
+    public $createdAt;
+    public $status;
 
-	private $log;
+    private $log;
 
     /**
      * Initiates the LetsEncrypt Account class.
@@ -58,30 +58,31 @@ class LEAccount
      * @param array 		$email	 		The array of strings containing e-mail addresses. Only used when creating a new account.
      * @param array 		$accountKeys 	Array containing location of account keys files.
      */
-	public function __construct($connector, $log, $email, $accountKeys)
-	{
-		$this->connector = $connector;
-		$this->accountKeys = $accountKeys;
-		$this->log = $log;
+    public function __construct($connector, $log, $email, $accountKeys)
+    {
+        $this->connector = $connector;
+        $this->accountKeys = $accountKeys;
+        $this->log = $log;
 
-		if(!file_exists($this->accountKeys['private_key']) OR !file_exists($this->accountKeys['public_key']))
-		{
-			if($this->log instanceof \Psr\Log\LoggerInterface) 
-			{
-				$this->log->info('No account found, attempting to create account.');
-			}
-			else if($this->log >= LECLient::LOG_STATUS) LEFunctions::log('No account found, attempting to create account.', 'function LEAccount __construct');
-			
-			LEFunctions::RSAgenerateKeys(null, $this->accountKeys['private_key'], $this->accountKeys['public_key']);
-			$this->connector->accountURL = $this->createLEAccount($email);
-		}
-		else
-		{
-			$this->connector->accountURL = $this->getLEAccount();
-		}
-		if($this->connector->accountURL == false) throw new \RuntimeException('Account not found or deactivated.');
-		$this->getLEAccountData();
-	}
+        if (!file_exists($this->accountKeys['private_key']) || !file_exists($this->accountKeys['public_key'])) {
+            if ($this->log instanceof \Psr\Log\LoggerInterface) {
+                $this->log->info('No account found, attempting to create account.');
+            } elseif ($this->log >= LECLient::LOG_STATUS) {
+                LEFunctions::log('No account found, attempting to create account.', 'function LEAccount __construct');
+            }
+
+            LEFunctions::RSAgenerateKeys(null, $this->accountKeys['private_key'], $this->accountKeys['public_key']);
+            $this->connector->accountURL = $this->createLEAccount($email);
+        } else {
+            $this->connector->accountURL = $this->getLEAccount();
+        }
+
+        if ($this->connector->accountURL == false) {
+            throw new \RuntimeException('Account not found or deactivated.');
+        }
+
+        $this->getLEAccountData();
+    }
 
     /**
      * Creates a new LetsEncrypt account.
@@ -90,58 +91,63 @@ class LEAccount
      *
      * @return object	Returns the new account URL when the account was successfully created, false if not.
      */
-	private function createLEAccount($email)
-	{
-		$contact = array_map(function($addr) { return empty($addr) ? '' : (strpos($addr, 'mailto') === false ? 'mailto:' . $addr : $addr); }, $email);
+    private function createLEAccount($email)
+    {
+        $contact = array_map(function ($addr) {
+            return empty($addr) ? '' : (strpos($addr, 'mailto') === false ? 'mailto:' . $addr : $addr);
+        }, $email);
 
-		$sign = $this->connector->signRequestJWK(array('contact' => $contact, 'termsOfServiceAgreed' => true), $this->connector->newAccount);
-		$post = $this->connector->post($this->connector->newAccount, $sign);
-		if(strpos($post['header'], "201 Created") !== false)
-		{
-			if(preg_match('~Location: (\S+)~i', $post['header'], $matches)) return trim($matches[1]);
-		}
-		return false;
-	}
+        $sign = $this->connector->signRequestJWK(['contact' => $contact, 'termsOfServiceAgreed' => true], $this->connector->newAccount);
+        $post = $this->connector->post($this->connector->newAccount, $sign);
+
+        if (strpos($post['header'], "201 Created") !== false) {
+            if (preg_match('~Location: (\S+)~i', $post['header'], $matches)) {
+                return trim($matches[1]);
+            }
+        }
+
+        return false;
+    }
 
     /**
      * Gets the LetsEncrypt account URL associated with the stored account keys.
      *
      * @return object	Returns the account URL if it is found, or false when none is found.
      */
-	private function getLEAccount()
-	{
-		$sign = $this->connector->signRequestJWK(array('onlyReturnExisting' => true), $this->connector->newAccount);
-		$post = $this->connector->post($this->connector->newAccount, $sign);
+    private function getLEAccount()
+    {
+        $sign = $this->connector->signRequestJWK(['onlyReturnExisting' => true], $this->connector->newAccount);
+        $post = $this->connector->post($this->connector->newAccount, $sign);
 
-		if(strpos($post['header'], "200 OK") !== false)
-		{
-			if(preg_match('~Location: (\S+)~i', $post['header'], $matches)) return trim($matches[1]);
-		}
-		return false;
-	}
+        if (strpos($post['header'], "200 OK") !== false) {
+            if (preg_match('~Location: (\S+)~i', $post['header'], $matches)) {
+                return trim($matches[1]);
+            }
+        }
+
+        return false;
+    }
 
     /**
      * Gets the LetsEncrypt account data from the account URL.
      */
-	private function getLEAccountData()
-	{
-		$sign = $this->connector->signRequestKid(array('' => ''), $this->connector->accountURL, $this->connector->accountURL);
-		$post = $this->connector->post($this->connector->accountURL, $sign);
-		if(strpos($post['header'], "200 OK") !== false)
-		{
-			$this->id = isset($post['body']['id']) ? $post['body']['id'] : '';
-			$this->key = $post['body']['key'];
-			$this->contact = $post['body']['contact'];
-			$this->agreement = isset($post['body']['agreement']) ? $post['body']['agreement'] : '';
-			$this->initialIp = $post['body']['initialIp'];
-			$this->createdAt = $post['body']['createdAt'];
-			$this->status = $post['body']['status'];
-		}
-		else
-		{
-			throw new \RuntimeException('Account data cannot be found.');
-		}
-	}
+    private function getLEAccountData()
+    {
+        $sign = $this->connector->signRequestKid(['' => ''], $this->connector->accountURL, $this->connector->accountURL);
+        $post = $this->connector->post($this->connector->accountURL, $sign);
+
+        if (strpos($post['header'], "200 OK") !== false) {
+            $this->id = isset($post['body']['id']) ? $post['body']['id'] : '';
+            $this->key = $post['body']['key'];
+            $this->contact = $post['body']['contact'];
+            $this->agreement = isset($post['body']['agreement']) ? $post['body']['agreement'] : '';
+            $this->initialIp = $post['body']['initialIp'];
+            $this->createdAt = $post['body']['createdAt'];
+            $this->status = $post['body']['status'];
+        } else {
+            throw new \RuntimeException('Account data cannot be found.');
+        }
+    }
 
     /**
      * Updates account data. Now just supporting new contact information.
@@ -150,95 +156,98 @@ class LEAccount
      *
      * @return boolean	Returns true if the update is successful, false if not.
      */
-	public function updateAccount($email)
-	{
-		$contact = array_map(function($addr) { return empty($addr) ? '' : (strpos($addr, 'mailto') === false ? 'mailto:' . $addr : $addr); }, $email);
+    public function updateAccount($email)
+    {
+        $contact = array_map(function ($addr) {
+            return empty($addr) ? '' : (strpos($addr, 'mailto') === false ? 'mailto:' . $addr : $addr);
+        }, $email);
 
-		$sign = $this->connector->signRequestKid(array('contact' => $contact), $this->connector->accountURL, $this->connector->accountURL);
-		$post = $this->connector->post($this->connector->accountURL, $sign);
-		if(strpos($post['header'], "200 OK") !== false)
-		{
-			$this->id = $post['body']['id'];
-			$this->key = $post['body']['key'];
-			$this->contact = $post['body']['contact'];
-			$this->agreement = isset($post['body']['agreement']) ? $post['body']['agreement'] : '';
-			$this->initialIp = $post['body']['initialIp'];
-			$this->createdAt = $post['body']['createdAt'];
-			$this->status = $post['body']['status'];
-			if($this->log instanceof \Psr\Log\LoggerInterface) 
-			{
-				$this->log->info('Account data updated.');
-			}
-			else if($this->log >= LEClient::LOG_STATUS) LEFunctions::log('Account data updated.', 'function updateAccount');
-			return true;
-		}
-		else
-		{
-			return false;
-		}
-	}
+        $sign = $this->connector->signRequestKid(['contact' => $contact], $this->connector->accountURL, $this->connector->accountURL);
+        $post = $this->connector->post($this->connector->accountURL, $sign);
+
+        if (strpos($post['header'], "200 OK") !== false) {
+            $this->id = $post['body']['id'];
+            $this->key = $post['body']['key'];
+            $this->contact = $post['body']['contact'];
+            $this->agreement = isset($post['body']['agreement']) ? $post['body']['agreement'] : '';
+            $this->initialIp = $post['body']['initialIp'];
+            $this->createdAt = $post['body']['createdAt'];
+            $this->status = $post['body']['status'];
+
+            if ($this->log instanceof \Psr\Log\LoggerInterface) {
+                $this->log->info('Account data updated.');
+            } elseif ($this->log >= LEClient::LOG_STATUS) {
+                LEFunctions::log('Account data updated.', 'function updateAccount');
+            }
+
+            return true;
+        }
+
+        return false;
+    }
 
     /**
      * Creates new RSA account keys and updates the keys with LetsEncrypt.
      *
      * @return boolean	Returns true if the update is successful, false if not.
      */
-	public function changeAccountKeys()
-	{
-		LEFunctions::RSAgenerateKeys(null, $this->accountKeys['private_key'].'.new', $this->accountKeys['public_key'].'.new');
-		$oldPrivateKey = openssl_pkey_get_private(file_get_contents($this->accountKeys['private_key']));
-		$oldDetails = openssl_pkey_get_details($oldPrivateKey);
-		$innerPayload = array('account' => $this->connector->accountURL, 'oldKey' => array(
-			"kty" => "RSA",
-			"n" => LEFunctions::Base64UrlSafeEncode($oldDetails["rsa"]["n"]),
-			"e" => LEFunctions::Base64UrlSafeEncode($oldDetails["rsa"]["e"])
-		));
-		$outerPayload = $this->connector->signRequestJWK($innerPayload, $this->connector->keyChange, $this->accountKeys['private_key'].'.new');
-		$sign = $this->connector->signRequestKid($outerPayload, $this->connector->accountURL, $this->connector->keyChange);
-		$post = $this->connector->post($this->connector->keyChange, $sign);
-		if(strpos($post['header'], "200 OK") !== false)
-		{
-			unlink($this->accountKeys['private_key']);
-			unlink($this->accountKeys['public_key']);
-			rename($this->accountKeys['private_key'].'.new', $this->accountKeys['private_key']);
-			rename($this->accountKeys['public_key'].'.new', $this->accountKeys['public_key']);
-			
-			$this->getLEAccountData();
+    public function changeAccountKeys()
+    {
+        LEFunctions::RSAgenerateKeys(null, $this->accountKeys['private_key'].'.new', $this->accountKeys['public_key'].'.new');
 
-			if($this->log instanceof \Psr\Log\LoggerInterface) 
-			{
-				$this->log->info('Account keys changed.');
-			}
-			elseif($this->log >= LEClient::LOG_STATUS) LEFunctions::log('Account keys changed.', 'function changeAccountKey');
-			return true;
-		}
-		else
-		{
-			return false;
-		}
-	}
+        $oldPrivateKey = openssl_pkey_get_private(file_get_contents($this->accountKeys['private_key']));
+        $oldDetails = openssl_pkey_get_details($oldPrivateKey);
+
+        $innerPayload = ['account' => $this->connector->accountURL, 'oldKey' => [
+            "kty" => "RSA",
+            "n" => LEFunctions::Base64UrlSafeEncode($oldDetails["rsa"]["n"]),
+            "e" => LEFunctions::Base64UrlSafeEncode($oldDetails["rsa"]["e"])
+        ]];
+
+        $outerPayload = $this->connector->signRequestJWK($innerPayload, $this->connector->keyChange, $this->accountKeys['private_key'].'.new');
+        $sign = $this->connector->signRequestKid($outerPayload, $this->connector->accountURL, $this->connector->keyChange);
+        $post = $this->connector->post($this->connector->keyChange, $sign);
+
+        if (strpos($post['header'], "200 OK") !== false) {
+            unlink($this->accountKeys['private_key']);
+            unlink($this->accountKeys['public_key']);
+            rename($this->accountKeys['private_key'].'.new', $this->accountKeys['private_key']);
+            rename($this->accountKeys['public_key'].'.new', $this->accountKeys['public_key']);
+            
+            $this->getLEAccountData();
+
+            if ($this->log instanceof \Psr\Log\LoggerInterface) {
+                $this->log->info('Account keys changed.');
+            } elseif ($this->log >= LEClient::LOG_STATUS) {
+                LEFunctions::log('Account keys changed.', 'function changeAccountKey');
+            }
+
+            return true;
+        }
+
+        return false;
+    }
 
     /**
      * Deactivates the LetsEncrypt account.
      *
      * @return boolean	Returns true if the deactivation is successful, false if not.
      */
-	public function deactivateAccount()
-	{
-		$sign = $this->connector->signRequestKid(array('status' => 'deactivated'), $this->connector->accountURL, $this->connector->accountURL);
-		$post = $this->connector->post($this->connector->accountURL, $sign);
-		if(strpos($post['header'], "200 OK") !== false)
-		{
-			$this->connector->accountDeactivated = true;
-			if($this->log instanceof \Psr\Log\LoggerInterface) 
-			{
-				$this->log->info('Account deactivated.');
-			}
-			elseif($this->log >= LEClient::LOG_STATUS) LEFunctions::log('Account deactivated.', 'function deactivateAccount');
-		}
-		else
-		{
-			return false;
-		}
-	}
+    public function deactivateAccount()
+    {
+        $sign = $this->connector->signRequestKid(['status' => 'deactivated'], $this->connector->accountURL, $this->connector->accountURL);
+        $post = $this->connector->post($this->connector->accountURL, $sign);
+
+        if (strpos($post['header'], "200 OK") !== false) {
+            $this->connector->accountDeactivated = true;
+
+            if ($this->log instanceof \Psr\Log\LoggerInterface) {
+                $this->log->info('Account deactivated.');
+            } elseif ($this->log >= LEClient::LOG_STATUS) {
+                LEFunctions::log('Account deactivated.', 'function deactivateAccount');
+            }
+        }
+
+        return false;
+    }
 }

--- a/src/LEAuthorization.php
+++ b/src/LEAuthorization.php
@@ -37,15 +37,15 @@ namespace LEClient;
  */
 class LEAuthorization
 {
-	private $connector;
+    private $connector;
 
-	public $authorizationURL;
-	public $identifier;
-	public $status;
-	public $expires;
-	public $challenges;
+    public $authorizationURL;
+    public $identifier;
+    public $status;
+    public $expires;
+    public $challenges;
 
-	private $log;
+    private $log;
 
     /**
      * Initiates the LetsEncrypt Authorization class. Child of a LetsEncrypt Order instance.
@@ -54,68 +54,65 @@ class LEAuthorization
      * @param int 			$log 				The level of logging. Defaults to no logging. LOG_OFF, LOG_STATUS, LOG_DEBUG accepted.
      * @param string 		$authorizationURL 	The URL of the authorization, given by a LetsEncrypt order request.
      */
-	public function __construct($connector, $log, $authorizationURL)
-	{
-		$this->connector = $connector;
-		$this->log = $log;
-		$this->authorizationURL = $authorizationURL;
+    public function __construct($connector, $log, $authorizationURL)
+    {
+        $this->connector = $connector;
+        $this->log = $log;
+        $this->authorizationURL = $authorizationURL;
 
-		$get = $this->connector->get($this->authorizationURL);
-		if(strpos($get['header'], "200 OK") !== false)
-		{
-			$this->identifier = $get['body']['identifier'];
-			$this->status = $get['body']['status'];
-			$this->expires = $get['body']['expires'];
-			$this->challenges = $get['body']['challenges'];
-		}
-		else
-		{
-			if($this->log instanceof \Psr\Log\LoggerInterface) 
-			{
-				$this->log->info('Cannot find authorization \'' . $authorizationURL . '\'.');
-			}
-			elseif($this->log >= LEClient::LOG_STATUS) LEFunctions::log('Cannot find authorization \'' . $authorizationURL . '\'.', 'function LEAuthorization __construct');
-		}
-	}
+        $get = $this->connector->get($this->authorizationURL);
+
+        if (strpos($get['header'], "200 OK") !== false) {
+            $this->identifier = $get['body']['identifier'];
+            $this->status = $get['body']['status'];
+            $this->expires = $get['body']['expires'];
+            $this->challenges = $get['body']['challenges'];
+        } else {
+            if ($this->log instanceof \Psr\Log\LoggerInterface) {
+                $this->log->info('Cannot find authorization \'' . $authorizationURL . '\'.');
+            } elseif ($this->log >= LEClient::LOG_STATUS) {
+                LEFunctions::log('Cannot find authorization \'' . $authorizationURL . '\'.', 'function LEAuthorization __construct');
+            }
+        }
+    }
 
     /**
      * Updates the data associated with the current LetsEncrypt Authorization instance.
      */
+    public function updateData()
+    {
+        $get = $this->connector->get($this->authorizationURL);
 
-	public function updateData()
-	{
-		$get = $this->connector->get($this->authorizationURL);
-		if(strpos($get['header'], "200 OK") !== false)
-		{
-			$this->identifier = $get['body']['identifier'];
-			$this->status = $get['body']['status'];
-			$this->expires = $get['body']['expires'];
-			$this->challenges = $get['body']['challenges'];
-		}
-		else
-		{
-			if($this->log instanceof \Psr\Log\LoggerInterface) 
-			{
-				$this->log->info('Cannot find authorization \'' . $this->authorizationURL . '\'.');
-			}
-			elseif($this->log >= LEClient::LOG_STATUS) LEFunctions::log('Cannot find authorization \'' . $this->authorizationURL . '\'.', 'function updateData');
-		}
-	}
+        if (strpos($get['header'], "200 OK") !== false) {
+            $this->identifier = $get['body']['identifier'];
+            $this->status = $get['body']['status'];
+            $this->expires = $get['body']['expires'];
+            $this->challenges = $get['body']['challenges'];
+        } else {
+            if ($this->log instanceof \Psr\Log\LoggerInterface) {
+                $this->log->info('Cannot find authorization \'' . $this->authorizationURL . '\'.');
+            } elseif ($this->log >= LEClient::LOG_STATUS) {
+                LEFunctions::log('Cannot find authorization \'' . $this->authorizationURL . '\'.', 'function updateData');
+            }
+        }
+    }
 
     /**
      * Gets the challenge of the given $type for this LetsEncrypt Authorization instance. Throws a Runtime Exception if the given $type is not found in this
-	 * LetsEncrypt Authorization instance.
+     * LetsEncrypt Authorization instance.
      *
      * @param int	$type 	The type of verification. Supporting LEOrder::CHALLENGE_TYPE_HTTP and LEOrder::CHALLENGE_TYPE_DNS.
      *
      * @return array	Returns an array with the challenge of the requested $type.
      */
-	public function getChallenge($type)
-	{
-		foreach($this->challenges as $challenge)
-		{
-			if($challenge['type'] == $type) return $challenge;
-		}
-		throw new \RuntimeException('No challenge found for type \'' . $type . '\' and identifier \'' . $this->identifier['value'] . '\'.');
-	}
+    public function getChallenge($type)
+    {
+        foreach ($this->challenges as $challenge) {
+            if ($challenge['type'] == $type) {
+                return $challenge;
+            }
+        }
+
+        throw new \RuntimeException('No challenge found for type \'' . $type . '\' and identifier \'' . $this->identifier['value'] . '\'.');
+    }
 }

--- a/src/LEClient.php
+++ b/src/LEClient.php
@@ -40,7 +40,7 @@ class LEClient
 	const LE_PRODUCTION = 'https://acme-v02.api.letsencrypt.org';
 	const LE_STAGING = 'https://acme-staging-v02.api.letsencrypt.org';
 
-	private $certificatesKeys;
+	private $certificateKeys;
 	private $accountKeys;
 
 	private $connector;

--- a/src/LEClient.php
+++ b/src/LEClient.php
@@ -99,13 +99,13 @@ class LEClient
                 LEFunctions::createhtaccess($certificateKeys);
             }
 
-            $this->certificateKeys = [
+            $this->certificateKeys = array(
                 "public_key" => $certificateKeys.'/public.pem',
                 "private_key" => $certificateKeys.'/private.pem',
                 "certificate" => $certificateKeys.'/certificate.crt',
                 "fullchain_certificate" => $certificateKeys.'/fullchain.crt',
                 "order" => $certificateKeys.'/order'
-            ];
+            );
         }
 
         if (is_array($certificateKeys)) {
@@ -145,10 +145,10 @@ class LEClient
                 LEFunctions::createhtaccess($accountKeys);
             }
 
-            $this->accountKeys = [
+            $this->accountKeys = array(
                 "private_key" => $accountKeys.'/private.pem',
                 "public_key" => $accountKeys.'/public.pem'
-            ];
+            );
         }
 
         if (is_array($accountKeys)) {

--- a/src/LEConnector.php
+++ b/src/LEConnector.php
@@ -109,7 +109,7 @@ class LEConnector
             throw new \RuntimeException('The account was deactivated. No further requests can be made.');
         }
 
-        $headers = ['Accept: application/json', 'Content-Type: application/jose+json'];
+        $headers = array('Accept: application/json', 'Content-Type: application/jose+json');
         $requestURL = preg_match('~^http~', $URL) ? $URL : $this->baseURL . $URL;
 
         $handle = curl_init();
@@ -150,7 +150,7 @@ class LEConnector
         $body = substr($response, $header_size);
 
         $jsonbody = json_decode($body, true);
-        $jsonresponse = ['request' => $method . ' ' . $requestURL, 'header' => $header, 'body' => $jsonbody === null ? $body : $jsonbody];
+        $jsonresponse = array('request' => $method . ' ' . $requestURL, 'header' => $header, 'body' => $jsonbody === null ? $body : $jsonbody);
 
         if ($this->log instanceof \Psr\Log\LoggerInterface) {
             $this->log->debug($method . ' response received', $jsonresponse);
@@ -230,16 +230,16 @@ class LEConnector
         $privateKey = openssl_pkey_get_private(file_get_contents($privateKeyFile));
         $details = openssl_pkey_get_details($privateKey);
 
-        $protected = [
+        $protected = array(
             "alg" => "RS256",
-            "jwk" => [
+            "jwk" => array(
                 "kty" => "RSA",
                 "n" => LEFunctions::Base64UrlSafeEncode($details["rsa"]["n"]),
                 "e" => LEFunctions::Base64UrlSafeEncode($details["rsa"]["e"]),
-            ],
+            ),
             "nonce" => $this->nonce,
             "url" => $url
-        ];
+        );
 
         $payload64 = LEFunctions::Base64UrlSafeEncode(str_replace('\\/', '/', is_array($payload) ? json_encode($payload) : $payload));
         $protected64 = LEFunctions::Base64UrlSafeEncode(json_encode($protected));
@@ -247,11 +247,11 @@ class LEConnector
         openssl_sign($protected64.'.'.$payload64, $signed, $privateKey, "SHA256");
         $signed64 = LEFunctions::Base64UrlSafeEncode($signed);
 
-        $data = [
+        $data = array(
             'protected' => $protected64,
             'payload' => $payload64,
             'signature' => $signed64
-        ];
+        );
 
         return json_encode($data);
     }
@@ -274,12 +274,12 @@ class LEConnector
 
         $privateKey = openssl_pkey_get_private(file_get_contents($privateKeyFile));
 
-        $protected = [
+        $protected = array(
             "alg" => "RS256",
             "kid" => $kid,
             "nonce" => $this->nonce,
             "url" => $url
-        ];
+        );
 
         $payload64 = LEFunctions::Base64UrlSafeEncode(str_replace('\\/', '/', is_array($payload) ? json_encode($payload) : $payload));
         $protected64 = LEFunctions::Base64UrlSafeEncode(json_encode($protected));
@@ -287,11 +287,11 @@ class LEConnector
         openssl_sign($protected64.'.'.$payload64, $signed, $privateKey, "SHA256");
         $signed64 = LEFunctions::Base64UrlSafeEncode($signed);
 
-        $data = [
+        $data = array(
             'protected' => $protected64,
             'payload' => $payload64,
             'signature' => $signed64
-        ];
+        );
 
         return json_encode($data);
     }

--- a/src/LEFunctions.php
+++ b/src/LEFunctions.php
@@ -53,10 +53,10 @@ class LEFunctions
             throw new \RuntimeException("RSA key size must be between 2048 and 4096.");
         }
 
-        $res = openssl_pkey_new([
+        $res = openssl_pkey_new(array(
             "private_key_type" => OPENSSL_KEYTYPE_RSA,
             "private_key_bits" => intval($keySize),
-        ]);
+        ));
 
         if ($res === false) {
             $error = "Could not generate key pair! Check your OpenSSL configuration. OpenSSL Error: ".PHP_EOL;
@@ -110,17 +110,17 @@ class LEFunctions
         }
 
         if ($keySize == 256) {
-            $res = openssl_pkey_new([
+            $res = openssl_pkey_new(array(
                 "private_key_type" => OPENSSL_KEYTYPE_EC,
                 "curve_name" => "prime256v1",
-            ]);
+            ));
         }
 
         if ($keySize == 384) {
-            $res = openssl_pkey_new([
+            $res = openssl_pkey_new(array(
                 "private_key_type" => OPENSSL_KEYTYPE_EC,
                 "curve_name" => "secp384r1",
-            ]);
+            ));
         }
 
         if (!openssl_pkey_export($res, $privateKey)) {

--- a/src/LEOrder.php
+++ b/src/LEOrder.php
@@ -37,27 +37,26 @@ namespace LEClient;
  */
 class LEOrder
 {
-	private $connector;
+    private $connector;
 
-	private $basename;
-	private $certificateKeys;
-	private $orderURL;
-	private $keyType;
-	private $keySize;
+    private $basename;
+    private $certificateKeys;
+    private $orderURL;
+    private $keyType;
+    private $keySize;
 
-	public $status;
-	public $expires;
-	public $identifiers;
-	private $authorizationURLs;
-	public $authorizations;
-	public $finalizeURL;
-	public $certificateURL;
+    public $status;
+    public $expires;
+    public $identifiers;
+    private $authorizationURLs;
+    public $authorizations;
+    public $finalizeURL;
+    public $certificateURL;
 
-	private $log;
+    private $log;
 
-
-	const CHALLENGE_TYPE_HTTP = 'http-01';
-	const CHALLENGE_TYPE_DNS = 'dns-01';
+    const CHALLENGE_TYPE_HTTP = 'http-01';
+    const CHALLENGE_TYPE_DNS = 'dns-01';
 
     /**
      * Initiates the LetsEncrypt Order class. If the base name is found in the $keysDir directory, the order data is requested. If no order was found locally, if the request is invalid or when there is a change in domain names, a new order is created.
@@ -71,110 +70,114 @@ class LEOrder
      * @param string 		$notBefore 			A date string formatted like 0000-00-00T00:00:00Z (yyyy-mm-dd hh:mm:ss) at which the certificate becomes valid.
      * @param string 		$notAfter 			A date string formatted like 0000-00-00T00:00:00Z (yyyy-mm-dd hh:mm:ss) until which the certificate is valid.
      */
-	public function __construct($connector, $log, $certificateKeys, $basename, $domains, $keyType = 'rsa-4096', $notBefore, $notAfter)
-	{
-		$this->connector = $connector;
-		$this->basename = $basename;
-		$this->log = $log;
+    public function __construct($connector, $log, $certificateKeys, $basename, $domains, $keyType = 'rsa-4096', $notBefore, $notAfter)
+    {
+        $this->connector = $connector;
+        $this->basename = $basename;
+        $this->log = $log;
 
-		if ($keyType == 'rsa')
-		{
-			$this->keyType = 'rsa';
-			$this->keySize = 4096;
-		}
-		elseif ($keyType == 'ec')
-		{
-			$this->keyType = 'ec';
-			$this->keySize = 256;
-		}
-		else
-		{
-			preg_match_all('/^(rsa|ec)\-([0-9]{3,4})$/', $keyType, $keyTypeParts, PREG_SET_ORDER, 0);
+        if ($keyType == 'rsa') {
+            $this->keyType = 'rsa';
+            $this->keySize = 4096;
+        } elseif ($keyType == 'ec') {
+            $this->keyType = 'ec';
+            $this->keySize = 256;
+        } else {
+            preg_match_all('/^(rsa|ec)\-([0-9]{3,4})$/', $keyType, $keyTypeParts, PREG_SET_ORDER, 0);
 
-			if (!empty($keyTypeParts))
-			{
-				$this->keyType = $keyTypeParts[0][1];
-				$this->keySize = intval($keyTypeParts[0][2]);
-			}
-			else throw new \RuntimeException('Key type \'' . $keyType . '\' not supported.');
-		}
+            if (!empty($keyTypeParts)) {
+                $this->keyType = $keyTypeParts[0][1];
+                $this->keySize = intval($keyTypeParts[0][2]);
+            } else {
+                throw new \RuntimeException('Key type \'' . $keyType . '\' not supported.');
+            }
+        }
 
-		$this->certificateKeys = $certificateKeys;
+        $this->certificateKeys = $certificateKeys;
 
-		if(file_exists($this->certificateKeys['private_key']) AND file_exists($this->certificateKeys['order']) AND file_exists($this->certificateKeys['public_key']))
-		{
-			$this->orderURL = file_get_contents($this->certificateKeys['order']);
-			if (filter_var($this->orderURL, FILTER_VALIDATE_URL))
-			{
-				$get = $this->connector->get($this->orderURL);
-				if(strpos($get['header'], "200 OK") !== false && $get['body']['status'] != "invalid")
-				{
-					$orderdomains = array_map(function($ident) { return $ident['value']; }, $get['body']['identifiers']);
-					$diff = array_merge(array_diff($orderdomains, $domains), array_diff($domains, $orderdomains));
-					if(!empty($diff))
-					{
-						foreach ($this->certificateKeys as $file)
-						{
-							if (is_file($file)) rename($file, $file.'.old');
-						}
-						if($this->log instanceof \Psr\Log\LoggerInterface) 
-						{
-							$this->log->info('Domains do not match order data. Renaming current files and creating new order.');
-						}
-						elseif($this->log >= LEClient::LOG_STATUS) LEFunctions::log('Domains do not match order data. Renaming current files and creating new order.', 'function LEOrder __construct');
-						$this->createOrder($domains, $notBefore, $notAfter, $keyType);
-					}
-					else
-					{
-						$this->status = $get['body']['status'];
-						$this->expires = $get['body']['expires'];
-						$this->identifiers = $get['body']['identifiers'];
-						$this->authorizationURLs = $get['body']['authorizations'];
-						$this->finalizeURL = $get['body']['finalize'];
-						if(array_key_exists('certificate', $get['body'])) $this->certificateURL = $get['body']['certificate'];
-						$this->updateAuthorizations();
-					}
-				}
-				else
-				{
-					foreach ($this->certificateKeys as $file)
-					{
-						if (is_file($file)) unlink($file);
-					}
-					if($this->log instanceof \Psr\Log\LoggerInterface) 
-					{
-						$this->log->info('Order data for \'' . $this->basename . '\' invalid. Deleting order data and creating new order.');
-					}
-					elseif($this->log >= LEClient::LOG_STATUS) LEFunctions::log('Order data for \'' . $this->basename . '\' invalid. Deleting order data and creating new order.', 'function LEOrder __construct');
-					$this->createOrder($domains, $notBefore, $notAfter);
-				}
-			}
-			else
-			{
+        if (file_exists($this->certificateKeys['private_key'])
+            && file_exists($this->certificateKeys['order'])
+            && file_exists($this->certificateKeys['public_key'])
+        ) {
+            $this->orderURL = file_get_contents($this->certificateKeys['order']);
 
-				foreach ($this->certificateKeys as $file)
-				{
-					if (is_file($file)) unlink($file);
-				}
-				if($this->log instanceof \Psr\Log\LoggerInterface) 
-				{
-					$this->log->info('Order data for \'' . $this->basename . '\' invalid. Deleting order data and creating new order.');
-				}
-				elseif($this->log >= LEClient::LOG_STATUS) LEFunctions::log('Order data for \'' . $this->basename . '\' invalid. Deleting order data and creating new order.', 'function LEOrder __construct');
+            if (filter_var($this->orderURL, FILTER_VALIDATE_URL)) {
+                $get = $this->connector->get($this->orderURL);
 
-				$this->createOrder($domains, $notBefore, $notAfter);
-			}
-		}
-		else
-		{
-			if($this->log instanceof \Psr\Log\LoggerInterface) 
-			{
-				$this->log->info('No order found for \'' . $this->basename . '\'. Creating new order.');
-			}
-			elseif($this->log >= LEClient::LOG_STATUS) LEFunctions::log('No order found for \'' . $this->basename . '\'. Creating new order.', 'function LEOrder __construct');
-			$this->createOrder($domains, $notBefore, $notAfter);
-		}
-	}
+                if (strpos($get['header'], '200 OK') !== false && $get['body']['status'] != 'invalid') {
+                    $orderdomains = array_map(function ($ident) {
+                        return $ident['value'];
+                    }, $get['body']['identifiers']);
+
+                    $diff = array_merge(array_diff($orderdomains, $domains), array_diff($domains, $orderdomains));
+
+                    if (!empty($diff)) {
+                        foreach ($this->certificateKeys as $file) {
+                            if (is_file($file)) {
+                                rename($file, $file.'.old');
+                            }
+                        }
+
+                        if ($this->log instanceof \Psr\Log\LoggerInterface) {
+                            $this->log->info('Domains do not match order data. Renaming current files and creating new order.');
+                        } elseif ($this->log >= LEClient::LOG_STATUS) {
+                            LEFunctions::log('Domains do not match order data. Renaming current files and creating new order.', 'function LEOrder __construct');
+                        }
+
+                        $this->createOrder($domains, $notBefore, $notAfter, $keyType);
+                    } else {
+                        $this->status = $get['body']['status'];
+                        $this->expires = $get['body']['expires'];
+                        $this->identifiers = $get['body']['identifiers'];
+                        $this->authorizationURLs = $get['body']['authorizations'];
+                        $this->finalizeURL = $get['body']['finalize'];
+
+                        if (array_key_exists('certificate', $get['body'])) {
+                            $this->certificateURL = $get['body']['certificate'];
+                        }
+
+                        $this->updateAuthorizations();
+                    }
+                } else {
+                    foreach ($this->certificateKeys as $file) {
+                        if (is_file($file)) {
+                            unlink($file);
+                        }
+                    }
+
+                    if ($this->log instanceof \Psr\Log\LoggerInterface) {
+                        $this->log->info('Order data for \'' . $this->basename . '\' invalid. Deleting order data and creating new order.');
+                    } elseif ($this->log >= LEClient::LOG_STATUS) {
+                        LEFunctions::log('Order data for \'' . $this->basename . '\' invalid. Deleting order data and creating new order.', 'function LEOrder __construct');
+                    }
+
+                    $this->createOrder($domains, $notBefore, $notAfter);
+                }
+            } else {
+                foreach ($this->certificateKeys as $file) {
+                    if (is_file($file)) {
+                        unlink($file);
+                    }
+                }
+
+                if ($this->log instanceof \Psr\Log\LoggerInterface) {
+                    $this->log->info('Order data for \'' . $this->basename . '\' invalid. Deleting order data and creating new order.');
+                } elseif ($this->log >= LEClient::LOG_STATUS) {
+                    LEFunctions::log('Order data for \'' . $this->basename . '\' invalid. Deleting order data and creating new order.', 'function LEOrder __construct');
+                }
+
+                $this->createOrder($domains, $notBefore, $notAfter);
+            }
+        } else {
+            if ($this->log instanceof \Psr\Log\LoggerInterface) {
+                $this->log->info('No order found for \'' . $this->basename . '\'. Creating new order.');
+            } elseif ($this->log >= LEClient::LOG_STATUS) {
+                LEFunctions::log('No order found for \'' . $this->basename . '\'. Creating new order.', 'function LEOrder __construct');
+            }
+
+            $this->createOrder($domains, $notBefore, $notAfter);
+        }
+    }
 
     /**
      * Creates a new LetsEncrypt order and fills this instance with its data. Subsequently creates a new RSA keypair for the certificate.
@@ -183,288 +186,297 @@ class LEOrder
      * @param string 	$notBefore 	A date string formatted like 0000-00-00T00:00:00Z (yyyy-mm-dd hh:mm:ss) at which the certificate becomes valid.
      * @param string 	$notAfter 	A date string formatted like 0000-00-00T00:00:00Z (yyyy-mm-dd hh:mm:ss) until which the certificate is valid.
      */
-	private function createOrder($domains, $notBefore, $notAfter)
-	{
-		if(preg_match('~(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z|^$)~', $notBefore) AND preg_match('~(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z|^$)~', $notAfter))
-		{
+    private function createOrder($domains, $notBefore, $notAfter)
+    {
+        if (preg_match('~(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z|^$)~', $notBefore) and preg_match('~(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z|^$)~', $notAfter)) {
+            $dns = [];
 
-			$dns = array();
-			foreach($domains as $domain)
-			{
-				if(preg_match_all('~(\*\.)~', $domain) > 1) throw new \RuntimeException('Cannot create orders with multiple wildcards in one domain.');
-				$dns[] = array('type' => 'dns', 'value' => $domain);
-			}
-			$payload = array("identifiers" => $dns, 'notBefore' => $notBefore, 'notAfter' => $notAfter);
-			$sign = $this->connector->signRequestKid($payload, $this->connector->accountURL, $this->connector->newOrder);
-			$post = $this->connector->post($this->connector->newOrder, $sign);
+            foreach ($domains as $domain) {
+                if (preg_match_all('~(\*\.)~', $domain) > 1) {
+                    throw new \RuntimeException('Cannot create orders with multiple wildcards in one domain.');
+                }
+                $dns[] = ['type' => 'dns', 'value' => $domain];
+            }
 
-			if(strpos($post['header'], "201 Created") !== false)
-			{
-				if(preg_match('~Location: (\S+)~i', $post['header'], $matches))
-				{
-					$this->orderURL = trim($matches[1]);
-					file_put_contents($this->certificateKeys['order'], $this->orderURL);
-					if ($this->keyType == "rsa")
-					{
-						LEFunctions::RSAgenerateKeys(null, $this->certificateKeys['private_key'], $this->certificateKeys['public_key'], $this->keySize);
-					}
-					elseif ($this->keyType == "ec")
-					{
-						LEFunctions::ECgenerateKeys(null, $this->certificateKeys['private_key'], $this->certificateKeys['public_key'], $this->keySize);
-					}
-					else
-					{
-						throw new \RuntimeException('Key type \'' . $this->keyType . '\' not supported.');
-					}
+            $payload = ["identifiers" => $dns, 'notBefore' => $notBefore, 'notAfter' => $notAfter];
+            $sign = $this->connector->signRequestKid($payload, $this->connector->accountURL, $this->connector->newOrder);
+            $post = $this->connector->post($this->connector->newOrder, $sign);
 
-					$this->status = $post['body']['status'];
-					$this->expires = $post['body']['expires'];
-					$this->identifiers = $post['body']['identifiers'];
-					$this->authorizationURLs = $post['body']['authorizations'];
-					$this->finalizeURL = $post['body']['finalize'];
-					if(array_key_exists('certificate', $post['body'])) $this->certificateURL = $post['body']['certificate'];
-					$this->updateAuthorizations();
+            if (strpos($post['header'], "201 Created") !== false) {
+                if (preg_match('~Location: (\S+)~i', $post['header'], $matches)) {
+                    $this->orderURL = trim($matches[1]);
 
-					if($this->log instanceof \Psr\Log\LoggerInterface) 
-					{
-						$this->log->info('Created order for \'' . $this->basename . '\'.');
-					}
-					elseif($this->log >= LEClient::LOG_STATUS) LEFunctions::log('Created order for \'' . $this->basename . '\'.', 'function createOrder (function LEOrder __construct)');
-				}
-				else
-				{
-					throw new \RuntimeException('New-order returned invalid response.');
-				}
-			}
-			else
-			{
-				throw new \RuntimeException('Creating new order failed.');
-			}
-		}
-		else
-		{
-			throw new \RuntimeException('notBefore and notAfter fields must be empty or be a string similar to 0000-00-00T00:00:00Z');
-		}
-	}
+                    file_put_contents($this->certificateKeys['order'], $this->orderURL);
+
+                    if (!$this->keyType == 'rsa' && !$this->keyType == 'ec') {
+                        throw new \RuntimeException('Key type \'' . $this->keyType . '\' not supported.');
+                    }
+
+                    if ($this->keyType == 'rsa') {
+                        LEFunctions::RSAgenerateKeys(null, $this->certificateKeys['private_key'], $this->certificateKeys['public_key'], $this->keySize);
+                    }
+                    if ($this->keyType == 'ec') {
+                        LEFunctions::ECgenerateKeys(null, $this->certificateKeys['private_key'], $this->certificateKeys['public_key'], $this->keySize);
+                    }
+
+                    $this->status = $post['body']['status'];
+                    $this->expires = $post['body']['expires'];
+                    $this->identifiers = $post['body']['identifiers'];
+                    $this->authorizationURLs = $post['body']['authorizations'];
+                    $this->finalizeURL = $post['body']['finalize'];
+
+                    if (array_key_exists('certificate', $post['body'])) {
+                        $this->certificateURL = $post['body']['certificate'];
+                    }
+
+                    $this->updateAuthorizations();
+
+                    if ($this->log instanceof \Psr\Log\LoggerInterface) {
+                        $this->log->info('Created order for \'' . $this->basename . '\'.');
+                    } elseif ($this->log >= LEClient::LOG_STATUS) {
+                        LEFunctions::log('Created order for \'' . $this->basename . '\'.', 'function createOrder (function LEOrder __construct)');
+                    }
+                } else {
+                    throw new \RuntimeException('New-order returned invalid response.');
+                }
+            } else {
+                throw new \RuntimeException('Creating new order failed.');
+            }
+        } else {
+            throw new \RuntimeException('notBefore and notAfter fields must be empty or be a string similar to 0000-00-00T00:00:00Z');
+        }
+    }
 
     /**
      * Fetches the latest data concerning this LetsEncrypt Order instance and fills this instance with the new data.
      */
-	private function updateOrderData()
-	{
-		$get = $this->connector->get($this->orderURL);
-		if(strpos($get['header'], "200 OK") !== false)
-		{
-			$this->status = $get['body']['status'];
-			$this->expires = $get['body']['expires'];
-			$this->identifiers = $get['body']['identifiers'];
-			$this->authorizationURLs = $get['body']['authorizations'];
-			$this->finalizeURL = $get['body']['finalize'];
-			if(array_key_exists('certificate', $get['body'])) $this->certificateURL = $get['body']['certificate'];
-			$this->updateAuthorizations();
-		}
-		else
-		{
-			if($this->log instanceof \Psr\Log\LoggerInterface) 
-			{
-				$this->log->info('Cannot update data for order \'' . $this->basename . '\'.');
-			}
-			elseif($this->log >= LEClient::LOG_STATUS) LEFunctions::log('Cannot update data for order \'' . $this->basename . '\'.', 'function updateOrderData');
-		}
-	}
+    private function updateOrderData()
+    {
+        $get = $this->connector->get($this->orderURL);
 
-	/**
+        if (strpos($get['header'], "200 OK") !== false) {
+            $this->status = $get['body']['status'];
+            $this->expires = $get['body']['expires'];
+            $this->identifiers = $get['body']['identifiers'];
+            $this->authorizationURLs = $get['body']['authorizations'];
+            $this->finalizeURL = $get['body']['finalize'];
+
+            if (array_key_exists('certificate', $get['body'])) {
+                $this->certificateURL = $get['body']['certificate'];
+            }
+
+            $this->updateAuthorizations();
+        } else {
+            if ($this->log instanceof \Psr\Log\LoggerInterface) {
+                $this->log->info('Cannot update data for order \'' . $this->basename . '\'.');
+            } elseif ($this->log >= LEClient::LOG_STATUS) {
+                LEFunctions::log('Cannot update data for order \'' . $this->basename . '\'.', 'function updateOrderData');
+            }
+        }
+    }
+
+    /**
      * Fetches the latest data concerning all authorizations connected to this LetsEncrypt Order instance and creates and stores a new LetsEncrypt Authorization instance for each one.
      */
-	private function updateAuthorizations()
-	{
-		$this->authorizations = array();
-		foreach($this->authorizationURLs as $authURL)
-		{
-			if (filter_var($authURL, FILTER_VALIDATE_URL))
-			{
-				$auth = new LEAuthorization($this->connector, $this->log, $authURL);
-				if($auth != false) $this->authorizations[] = $auth;
-			}
-		}
-	}
+    private function updateAuthorizations()
+    {
+        $this->authorizations = [];
+
+        foreach ($this->authorizationURLs as $authURL) {
+            if (filter_var($authURL, FILTER_VALIDATE_URL)) {
+                $auth = new LEAuthorization($this->connector, $this->log, $authURL);
+
+                if ($auth != false) {
+                    $this->authorizations[] = $auth;
+                }
+            }
+        }
+    }
 
     /**
      * Walks all LetsEncrypt Authorization instances and returns whether they are all valid (verified).
      *
      * @return boolean	Returns true if all authorizations are valid (verified), returns false if not.
      */
-	public function allAuthorizationsValid()
-	{
-		if(count($this->authorizations) > 0)
-		{
-			foreach($this->authorizations as $auth)
-			{
-				if($auth->status != 'valid') return false;
-			}
-			return true;
-		}
-		return false;
-	}
+    public function allAuthorizationsValid()
+    {
+        if (count($this->authorizations) > 0) {
+            foreach ($this->authorizations as $auth) {
+                if ($auth->status != 'valid') {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        return false;
+    }
 
     /**
      * Get all pending LetsEncrypt Authorization instances and return the necessary data for verification. The data in the return object depends on the $type.
      *
      * @param int	$type	The type of verification to get. Supporting http-01 and dns-01. Supporting LEOrder::CHALLENGE_TYPE_HTTP and LEOrder::CHALLENGE_TYPE_DNS. Throws
-	 *						a Runtime Exception when requesting an unknown $type. Keep in mind a wildcard domain authorization only accepts LEOrder::CHALLENGE_TYPE_DNS.
+     *						a Runtime Exception when requesting an unknown $type. Keep in mind a wildcard domain authorization only accepts LEOrder::CHALLENGE_TYPE_DNS.
      *
      * @return object	Returns an array with verification data if successful, false if not pending LetsEncrypt Authorization instances were found. The return array always
-	 *					contains 'type' and 'identifier'. For LEOrder::CHALLENGE_TYPE_HTTP, the array contains 'filename' and 'content' for necessary the authorization file.
-	 *					For LEOrder::CHALLENGE_TYPE_DNS, the array contains 'DNSDigest', which is the content for the necessary DNS TXT entry.
+     *					contains 'type' and 'identifier'. For LEOrder::CHALLENGE_TYPE_HTTP, the array contains 'filename' and 'content' for necessary the authorization file.
+     *					For LEOrder::CHALLENGE_TYPE_DNS, the array contains 'DNSDigest', which is the content for the necessary DNS TXT entry.
      */
 
-	public function getPendingAuthorizations($type)
-	{
-		$authorizations = array();
+    public function getPendingAuthorizations($type)
+    {
+        $authorizations = [];
 
-		$privateKey = openssl_pkey_get_private(file_get_contents($this->connector->accountKeys['private_key']));
-		$details = openssl_pkey_get_details($privateKey);
+        $privateKey = openssl_pkey_get_private(file_get_contents($this->connector->accountKeys['private_key']));
+        $details = openssl_pkey_get_details($privateKey);
 
-		$header = array(
-			"e" => LEFunctions::Base64UrlSafeEncode($details["rsa"]["e"]),
-			"kty" => "RSA",
-			"n" => LEFunctions::Base64UrlSafeEncode($details["rsa"]["n"])
+        $header = [
+            "e" => LEFunctions::Base64UrlSafeEncode($details["rsa"]["e"]),
+            "kty" => "RSA",
+            "n" => LEFunctions::Base64UrlSafeEncode($details["rsa"]["n"])
 
-		);
-		$digest = LEFunctions::Base64UrlSafeEncode(hash('sha256', json_encode($header), true));
+        ];
 
-		foreach($this->authorizations as $auth)
-		{
-			if($auth->status == 'pending')
-			{
-				$challenge = $auth->getChallenge($type);
-				if($challenge['status'] == 'pending')
-				{
-					$keyAuthorization = $challenge['token'] . '.' . $digest;
-					switch(strtolower($type))
-					{
-						case LEOrder::CHALLENGE_TYPE_HTTP:
-							$authorizations[] = array('type' => LEOrder::CHALLENGE_TYPE_HTTP, 'identifier' => $auth->identifier['value'], 'filename' => $challenge['token'], 'content' => $keyAuthorization);
-							break;
-						case LEOrder::CHALLENGE_TYPE_DNS:
-							$DNSDigest = LEFunctions::Base64UrlSafeEncode(hash('sha256', $keyAuthorization, true));
-							$authorizations[] = array('type' => LEOrder::CHALLENGE_TYPE_DNS, 'identifier' => $auth->identifier['value'], 'DNSDigest' => $DNSDigest);
-							break;
-					}
-				}
-			}
-		}
+        $digest = LEFunctions::Base64UrlSafeEncode(hash('sha256', json_encode($header), true));
 
-		return count($authorizations) > 0 ? $authorizations : false;
-	}
+        foreach ($this->authorizations as $auth) {
+            if ($auth->status == 'pending') {
+                $challenge = $auth->getChallenge($type);
+
+                if ($challenge['status'] == 'pending') {
+                    $keyAuthorization = $challenge['token'] . '.' . $digest;
+
+                    switch (strtolower($type)) {
+                        case LEOrder::CHALLENGE_TYPE_HTTP:
+                            $authorizations[] = [
+                                'type' => LEOrder::CHALLENGE_TYPE_HTTP,
+                                'identifier' => $auth->identifier['value'],
+                                'filename' => $challenge['token'],
+                                'content' => $keyAuthorization,
+                            ];
+
+                            break;
+                        case LEOrder::CHALLENGE_TYPE_DNS:
+                            $DNSDigest = LEFunctions::Base64UrlSafeEncode(hash('sha256', $keyAuthorization, true));
+
+                            $authorizations[] = [
+                                'type' => LEOrder::CHALLENGE_TYPE_DNS,
+                                'identifier' => $auth->identifier['value'],
+                                'DNSDigest' => $DNSDigest,
+                            ];
+
+                            break;
+                    }
+                }
+            }
+        }
+
+        return count($authorizations) > 0 ? $authorizations : false;
+    }
 
     /**
      * Sends a verification request for a given $identifier and $type. The function itself checks whether the verification is valid before making the request.
-	 * Updates the LetsEncrypt Authorization instances after a successful verification.
+     * Updates the LetsEncrypt Authorization instances after a successful verification.
      *
      * @param string	$identifier	The domain name to verify.
      * @param int 		$type 		The type of verification. Supporting LEOrder::CHALLENGE_TYPE_HTTP and LEOrder::CHALLENGE_TYPE_DNS.
-	 * @param boolean	$localcheck	Whether to verify the authorization locally before making the authorization request to LE. Optional, default to true.
+     * @param boolean	$localcheck	Whether to verify the authorization locally before making the authorization request to LE. Optional, default to true.
      *
      * @return boolean	Returns true when the verification request was successful, false if not.
      */
-	public function verifyPendingOrderAuthorization($identifier, $type, $localcheck = true)
-	{
-		$privateKey = openssl_pkey_get_private(file_get_contents($this->connector->accountKeys['private_key']));
-		$details = openssl_pkey_get_details($privateKey);
+    public function verifyPendingOrderAuthorization($identifier, $type, $localcheck = true)
+    {
+        $privateKey = openssl_pkey_get_private(file_get_contents($this->connector->accountKeys['private_key']));
+        $details = openssl_pkey_get_details($privateKey);
 
-		$header = array(
-			"e" => LEFunctions::Base64UrlSafeEncode($details["rsa"]["e"]),
-			"kty" => "RSA",
-			"n" => LEFunctions::Base64UrlSafeEncode($details["rsa"]["n"])
+        $header = [
+            "e" => LEFunctions::Base64UrlSafeEncode($details["rsa"]["e"]),
+            "kty" => "RSA",
+            "n" => LEFunctions::Base64UrlSafeEncode($details["rsa"]["n"])
+        ];
 
-		);
-		$digest = LEFunctions::Base64UrlSafeEncode(hash('sha256', json_encode($header), true));
+        $digest = LEFunctions::Base64UrlSafeEncode(hash('sha256', json_encode($header), true));
 
-		foreach($this->authorizations as $auth)
-		{
-			if($auth->identifier['value'] == $identifier)
-			{
-				if($auth->status == 'pending')
-				{
-					$challenge = $auth->getChallenge($type);
-					if($challenge['status'] == 'pending')
-					{
-						$keyAuthorization = $challenge['token'] . '.' . $digest;
-						switch($type)
-						{
-							case LEOrder::CHALLENGE_TYPE_HTTP:
-								if($localcheck == false OR LEFunctions::checkHTTPChallenge($identifier, $challenge['token'], $keyAuthorization))
-								{
-									$sign = $this->connector->signRequestKid(array('keyAuthorization' => $keyAuthorization), $this->connector->accountURL, $challenge['url']);
-									$post = $this->connector->post($challenge['url'], $sign);
-									if(strpos($post['header'], "200 OK") !== false)
-									{
-										if($localcheck)
-										{
-											if($this->log instanceof \Psr\Log\LoggerInterface) 
-											{
-												$this->log->info('HTTP challenge for \'' . $identifier . '\' valid.');
-											}
-											elseif($this->log >= LEClient::LOG_STATUS) LEFunctions::log('HTTP challenge for \'' . $identifier . '\' valid.', 'function verifyPendingOrderAuthorization');
-										}
-										while($auth->status == 'pending')
-										{
-											sleep(1);
-											$auth->updateData();
-										}
-										return true;
-									}
-								}
-								else
-								{
-									if($this->log instanceof \Psr\Log\LoggerInterface) 
-									{
-										$this->log->info('HTTP challenge for \'' . $identifier . '\' tested locally, found invalid.');
-									}
-									elseif($this->log >= LEClient::LOG_STATUS) LEFunctions::log('HTTP challenge for \'' . $identifier . '\' tested locally, found invalid.', 'function verifyPendingOrderAuthorization');
-								}
-								break;
-							case LEOrder::CHALLENGE_TYPE_DNS:
-								$DNSDigest = LEFunctions::Base64UrlSafeEncode(hash('sha256', $keyAuthorization, true));
-								if($localcheck == false OR LEFunctions::checkDNSChallenge($identifier, $DNSDigest))
-								{
-									$sign = $this->connector->signRequestKid(array('keyAuthorization' => $keyAuthorization), $this->connector->accountURL, $challenge['url']);
-									$post = $this->connector->post($challenge['url'], $sign);
-									if(strpos($post['header'], "200 OK") !== false)
-									{
-										if($localcheck)
-										{
-											if($this->log instanceof \Psr\Log\LoggerInterface) 
-											{
-												$this->log->info('DNS challenge for \'' . $identifier . '\' valid.');
-											}
-											elseif($this->log >= LEClient::LOG_STATUS) LEFunctions::log('DNS challenge for \'' . $identifier . '\' valid.', 'function verifyPendingOrderAuthorization');
-										}
-										while($auth->status == 'pending')
-										{
-											sleep(1);
-											$auth->updateData();
-										}
-										return true;
-									}
-								}
-								else
-								{
-									if($this->log instanceof \Psr\Log\LoggerInterface) 
-									{
-										$this->log->info('DNS challenge for \'' . $identifier . '\' tested locally, found invalid.');
-									}
-									elseif($this->log >= LEClient::LOG_STATUS) LEFunctions::log('DNS challenge for \'' . $identifier . '\' tested locally, found invalid.', 'function verifyPendingOrderAuthorization');
-								}
-								break;
-						}
-					}
-				}
-			}
-		}
-		return false;
-	}
+        foreach ($this->authorizations as $auth) {
+            if ($auth->identifier['value'] == $identifier) {
+                if ($auth->status == 'pending') {
+                    $challenge = $auth->getChallenge($type);
+
+                    if ($challenge['status'] == 'pending') {
+                        $keyAuthorization = $challenge['token'] . '.' . $digest;
+
+                        switch ($type) {
+                            case LEOrder::CHALLENGE_TYPE_HTTP:
+                                if ($localcheck == false || LEFunctions::checkHTTPChallenge($identifier, $challenge['token'], $keyAuthorization)) {
+                                    $sign = $this->connector->signRequestKid(['keyAuthorization' => $keyAuthorization], $this->connector->accountURL, $challenge['url']);
+                                    $post = $this->connector->post($challenge['url'], $sign);
+
+                                    if (strpos($post['header'], "200 OK") !== false) {
+                                        if ($localcheck) {
+                                            if ($this->log instanceof \Psr\Log\LoggerInterface) {
+                                                $this->log->info('HTTP challenge for \'' . $identifier . '\' valid.');
+                                            } elseif ($this->log >= LEClient::LOG_STATUS) {
+                                                LEFunctions::log('HTTP challenge for \'' . $identifier . '\' valid.', 'function verifyPendingOrderAuthorization');
+                                            }
+                                        }
+
+                                        while ($auth->status == 'pending') {
+                                            sleep(1);
+                                            $auth->updateData();
+                                        }
+
+                                        return true;
+                                    }
+                                } else {
+                                    if ($this->log instanceof \Psr\Log\LoggerInterface) {
+                                        $this->log->info('HTTP challenge for \'' . $identifier . '\' tested locally, found invalid.');
+                                    } elseif ($this->log >= LEClient::LOG_STATUS) {
+                                        LEFunctions::log('HTTP challenge for \'' . $identifier . '\' tested locally, found invalid.', 'function verifyPendingOrderAuthorization');
+                                    }
+                                }
+
+                                break;
+                            case LEOrder::CHALLENGE_TYPE_DNS:
+                                $DNSDigest = LEFunctions::Base64UrlSafeEncode(hash('sha256', $keyAuthorization, true));
+
+                                if ($localcheck == false || LEFunctions::checkDNSChallenge($identifier, $DNSDigest)) {
+                                    $sign = $this->connector->signRequestKid(['keyAuthorization' => $keyAuthorization], $this->connector->accountURL, $challenge['url']);
+                                    $post = $this->connector->post($challenge['url'], $sign);
+
+                                    if (strpos($post['header'], "200 OK") !== false) {
+                                        if ($localcheck) {
+                                            if ($this->log instanceof \Psr\Log\LoggerInterface) {
+                                                $this->log->info('DNS challenge for \'' . $identifier . '\' valid.');
+                                            } elseif ($this->log >= LEClient::LOG_STATUS) {
+                                                LEFunctions::log('DNS challenge for \'' . $identifier . '\' valid.', 'function verifyPendingOrderAuthorization');
+                                            }
+                                        }
+
+                                        while ($auth->status == 'pending') {
+                                            sleep(1);
+                                            $auth->updateData();
+                                        }
+
+                                        return true;
+                                    }
+                                } else {
+                                    if ($this->log instanceof \Psr\Log\LoggerInterface) {
+                                        $this->log->info('DNS challenge for \'' . $identifier . '\' tested locally, found invalid.');
+                                    } elseif ($this->log >= LEClient::LOG_STATUS) {
+                                        LEFunctions::log('DNS challenge for \'' . $identifier . '\' tested locally, found invalid.', 'function verifyPendingOrderAuthorization');
+                                    }
+                                }
+
+                                break;
+                        }
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
 
     /**
      * Deactivate an LetsEncrypt Authorization instance.
@@ -473,68 +485,70 @@ class LEOrder
      *
      * @return boolean	Returns true is the deactivation request was successful, false if not.
      */
-	public function deactivateOrderAuthorization($identifier)
-	{
-		foreach($this->authorizations as $auth)
-		{
-			if($auth->identifier['value'] == $identifier)
-			{
-				$sign = $this->connector->signRequestKid(array('status' => 'deactivated'), $this->connector->accountURL, $auth->authorizationURL);
-				$post = $this->connector->post($auth->authorizationURL, $sign);
-				if(strpos($post['header'], "200 OK") !== false)
-				{
-					if($this->log instanceof \Psr\Log\LoggerInterface) 
-					{
-						$this->log->info('Authorization for \'' . $identifier . '\' deactivated.');
-					}
-					elseif($this->log >= LEClient::LOG_STATUS) LEFunctions::log('Authorization for \'' . $identifier . '\' deactivated.', 'function deactivateOrderAuthorization');
-					$this->updateAuthorizations();
-					return true;
-				}
-			}
-		}
-		if($this->log instanceof \Psr\Log\LoggerInterface) 
-		{
-			$this->log->info('No authorization found for \'' . $identifier . '\', cannot deactivate.');
-		}
-		elseif($this->log >= LEClient::LOG_STATUS) LEFunctions::log('No authorization found for \'' . $identifier . '\', cannot deactivate.', 'function deactivateOrderAuthorization');
-		return false;
-	}
+    public function deactivateOrderAuthorization($identifier)
+    {
+        foreach ($this->authorizations as $auth) {
+            if ($auth->identifier['value'] == $identifier) {
+                $sign = $this->connector->signRequestKid(['status' => 'deactivated'], $this->connector->accountURL, $auth->authorizationURL);
+                $post = $this->connector->post($auth->authorizationURL, $sign);
+
+                if (strpos($post['header'], "200 OK") !== false) {
+                    if ($this->log instanceof \Psr\Log\LoggerInterface) {
+                        $this->log->info('Authorization for \'' . $identifier . '\' deactivated.');
+                    } elseif ($this->log >= LEClient::LOG_STATUS) {
+                        LEFunctions::log('Authorization for \'' . $identifier . '\' deactivated.', 'function deactivateOrderAuthorization');
+                    }
+
+                    $this->updateAuthorizations();
+
+                    return true;
+                }
+            }
+        }
+
+        if ($this->log instanceof \Psr\Log\LoggerInterface) {
+            $this->log->info('No authorization found for \'' . $identifier . '\', cannot deactivate.');
+        } elseif ($this->log >= LEClient::LOG_STATUS) {
+            LEFunctions::log('No authorization found for \'' . $identifier . '\', cannot deactivate.', 'function deactivateOrderAuthorization');
+        }
+
+        return false;
+    }
 
     /**
      * Generates a Certificate Signing Request for the identifiers in the current LetsEncrypt Order instance. If possible, the base name will be the certificate
-	 * common name and all domain names in this LetsEncrypt Order instance will be added to the Subject Alternative Names entry.
+     * common name and all domain names in this LetsEncrypt Order instance will be added to the Subject Alternative Names entry.
      *
      * @return string	Returns the generated CSR as string, unprepared for LetsEncrypt. Preparation for the request happens in finalizeOrder()
      */
-	public function generateCSR()
-	{
-		$domains = array_map(function ($dns) { return $dns['value']; }, $this->identifiers);
-		if(in_array($this->basename, $domains))
-		{
-			$CN = $this->basename;
-		}
-		elseif(in_array('*.' . $this->basename, $domains))
-		{
-			$CN = '*.' . $this->basename;
-		}
-		else
-		{
-			$CN = $domains[0];
-		}
+    public function generateCSR()
+    {
+        $domains = array_map(function ($dns) {
+            return $dns['value'];
+        }, $this->identifiers);
 
-		$dn = array(
-			"commonName" => $CN
-		);
+        if (in_array($this->basename, $domains)) {
+            $CN = $this->basename;
+        } elseif (in_array('*.' . $this->basename, $domains)) {
+            $CN = '*.' . $this->basename;
+        } else {
+            $CN = $domains[0];
+        }
 
-		$san = implode(",", array_map(function ($dns) {
+        $dn = [
+            'commonName' => $CN
+        ];
+
+        $san = implode(",", array_map(function ($dns) {
             return "DNS:" . $dns;
         }, $domains));
+
         $tmpConf = tmpfile();
         $tmpConfMeta = stream_get_meta_data($tmpConf);
         $tmpConfPath = $tmpConfMeta["uri"];
 
-        fwrite($tmpConf,
+        fwrite(
+            $tmpConf,
             'HOME = .
 			RANDFILE = $ENV::HOME/.rnd
 			[ req ]
@@ -547,13 +561,16 @@ class LEOrder
 			[ v3_req ]
 			basicConstraints = CA:FALSE
 			subjectAltName = ' . $san . '
-			keyUsage = nonRepudiation, digitalSignature, keyEncipherment');
+			keyUsage = nonRepudiation, digitalSignature, keyEncipherment'
+        );
 
-		$privateKey = openssl_pkey_get_private(file_get_contents($this->certificateKeys['private_key']));
-		$csr = openssl_csr_new($dn, $privateKey, array('config' => $tmpConfPath, 'digest_alg' => 'sha256'));
-		openssl_csr_export ($csr, $csr);
-		return $csr;
-	}
+        $privateKey = openssl_pkey_get_private(file_get_contents($this->certificateKeys['private_key']));
+        $csr = openssl_csr_new($dn, $privateKey, ['config' => $tmpConfPath, 'digest_alg' => 'sha256']);
+
+        openssl_csr_export($csr, $csr);
+
+        return $csr;
+    }
 
     /**
      * Checks, for redundancy, whether all authorizations are valid, and finalizes the order. Updates this LetsEncrypt Order instance with the new data.
@@ -562,197 +579,205 @@ class LEOrder
      *
      * @return boolean	Returns true if the finalize request was successful, false if not.
      */
-	public function finalizeOrder($csr = '')
-	{
-		if($this->status == 'pending' || $this->status == 'ready')
-		{
-			if($this->allAuthorizationsValid())
-			{
-				if(empty($csr)) $csr = $this->generateCSR();
-				if(preg_match('~-----BEGIN\sCERTIFICATE\sREQUEST-----(.*)-----END\sCERTIFICATE\sREQUEST-----~s', $csr, $matches)) $csr = $matches[1];
-				$csr = trim(LEFunctions::Base64UrlSafeEncode(base64_decode($csr)));
-				$sign = $this->connector->signRequestKid(array('csr' => $csr), $this->connector->accountURL, $this->finalizeURL);
-				$post = $this->connector->post($this->finalizeURL, $sign);
-				if(strpos($post['header'], "200 OK") !== false)
-				{
-					$this->status = $post['body']['status'];
-					$this->expires = $post['body']['expires'];
-					$this->identifiers = $post['body']['identifiers'];
-					$this->authorizationURLs = $post['body']['authorizations'];
-					$this->finalizeURL = $post['body']['finalize'];
-					if(array_key_exists('certificate', $post['body'])) $this->certificateURL = $post['body']['certificate'];
-					$this->updateAuthorizations();
-					if($this->log instanceof \Psr\Log\LoggerInterface) 
-					{
-						$this->log->info('Order for \'' . $this->basename . '\' finalized.');
-					}
-					elseif($this->log >= LEClient::LOG_STATUS) LEFunctions::log('Order for \'' . $this->basename . '\' finalized.', 'function finalizeOrder');
-					return true;
-				}
-			}
-			else
-			{
-				if($this->log instanceof \Psr\Log\LoggerInterface) 
-				{
-					$this->log->info('Not all authorizations are valid for \'' . $this->basename . '\'. Cannot finalize order.');
-				}
-				elseif($this->log >= LEClient::LOG_STATUS) LEFunctions::log('Not all authorizations are valid for \'' . $this->basename . '\'. Cannot finalize order.', 'function finalizeOrder');
-			}
-		}
-		else
-		{
-			if($this->log instanceof \Psr\Log\LoggerInterface) 
-			{
-				$this->log->info('Order status for \'' . $this->basename . '\' is \'' . $this->status . '\'. Cannot finalize order.');
-			}
-			elseif($this->log >= LEClient::LOG_STATUS) LEFunctions::log('Order status for \'' . $this->basename . '\' is \'' . $this->status . '\'. Cannot finalize order.', 'function finalizeOrder');
-		}
-		return false;
-	}
+    public function finalizeOrder($csr = '')
+    {
+        if ($this->status == 'pending' || $this->status == 'ready') {
+            if ($this->allAuthorizationsValid()) {
+                if (empty($csr)) {
+                    $csr = $this->generateCSR();
+                }
+
+                if (preg_match('~-----BEGIN\sCERTIFICATE\sREQUEST-----(.*)-----END\sCERTIFICATE\sREQUEST-----~s', $csr, $matches)) {
+                    $csr = $matches[1];
+                }
+
+                $csr = trim(LEFunctions::Base64UrlSafeEncode(base64_decode($csr)));
+                $sign = $this->connector->signRequestKid(['csr' => $csr], $this->connector->accountURL, $this->finalizeURL);
+                $post = $this->connector->post($this->finalizeURL, $sign);
+
+                if (strpos($post['header'], "200 OK") !== false) {
+                    $this->status = $post['body']['status'];
+                    $this->expires = $post['body']['expires'];
+                    $this->identifiers = $post['body']['identifiers'];
+                    $this->authorizationURLs = $post['body']['authorizations'];
+                    $this->finalizeURL = $post['body']['finalize'];
+
+                    if (array_key_exists('certificate', $post['body'])) {
+                        $this->certificateURL = $post['body']['certificate'];
+                    }
+
+                    $this->updateAuthorizations();
+
+                    if ($this->log instanceof \Psr\Log\LoggerInterface) {
+                        $this->log->info('Order for \'' . $this->basename . '\' finalized.');
+                    } elseif ($this->log >= LEClient::LOG_STATUS) {
+                        LEFunctions::log('Order for \'' . $this->basename . '\' finalized.', 'function finalizeOrder');
+                    }
+
+                    return true;
+                }
+            } else {
+                if ($this->log instanceof \Psr\Log\LoggerInterface) {
+                    $this->log->info('Not all authorizations are valid for \'' . $this->basename . '\'. Cannot finalize order.');
+                } elseif ($this->log >= LEClient::LOG_STATUS) {
+                    LEFunctions::log('Not all authorizations are valid for \'' . $this->basename . '\'. Cannot finalize order.', 'function finalizeOrder');
+                }
+            }
+        } else {
+            if ($this->log instanceof \Psr\Log\LoggerInterface) {
+                $this->log->info('Order status for \'' . $this->basename . '\' is \'' . $this->status . '\'. Cannot finalize order.');
+            } elseif ($this->log >= LEClient::LOG_STATUS) {
+                LEFunctions::log('Order status for \'' . $this->basename . '\' is \'' . $this->status . '\'. Cannot finalize order.', 'function finalizeOrder');
+            }
+        }
+
+        return false;
+    }
 
     /**
      * Gets whether the LetsEncrypt Order is finalized by checking whether the status is processing or valid. Keep in mind, a certificate is not yet available when the status still is processing.
      *
      * @return boolean	Returns true if finalized, false if not.
      */
-	public function isFinalized()
-	{
-		return ($this->status == 'processing' || $this->status == 'valid');
-	}
+    public function isFinalized()
+    {
+        return ($this->status == 'processing' || $this->status == 'valid');
+    }
 
     /**
      * Requests the certificate for this LetsEncrypt Order instance, after finalization. When the order status is still 'processing', the order will be polled max
-	 * four times with five seconds in between. If the status becomes 'valid' in the meantime, the certificate will be requested. Else, the function returns false.
+     * four times with five seconds in between. If the status becomes 'valid' in the meantime, the certificate will be requested. Else, the function returns false.
      *
      * @return boolean	Returns true if the certificate is stored successfully, false if the certificate could not be retrieved or the status remained 'processing'.
      */
-	public function getCertificate()
-	{
-		$polling = 0;
-		while($this->status == 'processing' && $polling < 4)
-		{
-			if($this->log instanceof \Psr\Log\LoggerInterface) 
-			{
-				$this->log->info('Certificate for \'' . $this->basename . '\' being processed. Retrying in 5 seconds...');
-			}
-			elseif($this->log >= LEClient::LOG_STATUS) LEFunctions::log('Certificate for \'' . $this->basename . '\' being processed. Retrying in 5 seconds...', 'function getCertificate');
-			sleep(5);
-			$this->updateOrderData();
-			$polling++;
-		}
-		if($this->status == 'valid' && !empty($this->certificateURL))
-		{
-			$get = $this->connector->get($this->certificateURL);
-			if(strpos($get['header'], "200 OK") !== false)
-			{
-				if(preg_match_all('~(-----BEGIN\sCERTIFICATE-----[\s\S]+?-----END\sCERTIFICATE-----)~i', $get['body'], $matches))
-				{
-					if (isset($this->certificateKeys['certificate'])) file_put_contents($this->certificateKeys['certificate'],  $matches[0][0]);
+    public function getCertificate()
+    {
+        $polling = 0;
 
-					if(count($matches[0]) > 1 && isset($this->certificateKeys['fullchain_certificate']))
-					{
-						$fullchain = $matches[0][0]."\n";
-						for($i=1;$i<count($matches[0]);$i++)
-						{
-							$fullchain .= $matches[0][$i]."\n";
-						}
-						file_put_contents(trim($this->certificateKeys['fullchain_certificate']), $fullchain);
-					}
-					if($this->log instanceof \Psr\Log\LoggerInterface) 
-					{
-						$this->log->info('Certificate for \'' . $this->basename . '\' saved');
-					}
-					elseif($this->log >= LEClient::LOG_STATUS) LEFunctions::log('Certificate for \'' . $this->basename . '\' saved', 'function getCertificate');
-					return true;
-				}
-				else
-				{
-					if($this->log instanceof \Psr\Log\LoggerInterface) 
-					{
-						$this->log->info('Received invalid certificate for \'' . $this->basename . '\'. Cannot save certificate.');
-					}
-					elseif($this->log >= LEClient::LOG_STATUS) LEFunctions::log('Received invalid certificate for \'' . $this->basename . '\'. Cannot save certificate.', 'function getCertificate');
-				}
-			}
-			else
-			{
-				if($this->log instanceof \Psr\Log\LoggerInterface) 
-				{
-					$this->log->info('Invalid response for certificate request for \'' . $this->basename . '\'. Cannot save certificate.');
-				}
-				elseif($this->log >= LEClient::LOG_STATUS) LEFunctions::log('Invalid response for certificate request for \'' . $this->basename . '\'. Cannot save certificate.', 'function getCertificate');
-			}
-		}
-		else
-		{
-			if($this->log instanceof \Psr\Log\LoggerInterface) 
-			{
-				$this->log->info('Order for \'' . $this->basename . '\' not valid. Cannot retrieve certificate.');
-			}
-			elseif($this->log >= LEClient::LOG_STATUS) LEFunctions::log('Order for \'' . $this->basename . '\' not valid. Cannot retrieve certificate.', 'function getCertificate');
-		}
-		return false;
-	}
+        while ($this->status == 'processing' && $polling < 4) {
+            if ($this->log instanceof \Psr\Log\LoggerInterface) {
+                $this->log->info('Certificate for \'' . $this->basename . '\' being processed. Retrying in 5 seconds...');
+            } elseif ($this->log >= LEClient::LOG_STATUS) {
+                LEFunctions::log('Certificate for \'' . $this->basename . '\' being processed. Retrying in 5 seconds...', 'function getCertificate');
+            }
+
+            sleep(5);
+
+            $this->updateOrderData();
+
+            $polling++;
+        }
+
+        if ($this->status == 'valid' && !empty($this->certificateURL)) {
+            $get = $this->connector->get($this->certificateURL);
+
+            if (strpos($get['header'], "200 OK") !== false) {
+                if (preg_match_all('~(-----BEGIN\sCERTIFICATE-----[\s\S]+?-----END\sCERTIFICATE-----)~i', $get['body'], $matches)) {
+                    if (isset($this->certificateKeys['certificate'])) {
+                        file_put_contents($this->certificateKeys['certificate'], $matches[0][0]);
+                    }
+
+                    if (count($matches[0]) > 1 && isset($this->certificateKeys['fullchain_certificate'])) {
+                        $fullchain = $matches[0][0]."\n";
+
+                        for ($i = 1; $i < count($matches[0]); $i++) {
+                            $fullchain .= $matches[0][$i]."\n";
+                        }
+
+                        file_put_contents(trim($this->certificateKeys['fullchain_certificate']), $fullchain);
+                    }
+
+                    if ($this->log instanceof \Psr\Log\LoggerInterface) {
+                        $this->log->info('Certificate for \'' . $this->basename . '\' saved');
+                    } elseif ($this->log >= LEClient::LOG_STATUS) {
+                        LEFunctions::log('Certificate for \'' . $this->basename . '\' saved', 'function getCertificate');
+                    }
+
+                    return true;
+                } else {
+                    if ($this->log instanceof \Psr\Log\LoggerInterface) {
+                        $this->log->info('Received invalid certificate for \'' . $this->basename . '\'. Cannot save certificate.');
+                    } elseif ($this->log >= LEClient::LOG_STATUS) {
+                        LEFunctions::log('Received invalid certificate for \'' . $this->basename . '\'. Cannot save certificate.', 'function getCertificate');
+                    }
+                }
+            } else {
+                if ($this->log instanceof \Psr\Log\LoggerInterface) {
+                    $this->log->info('Invalid response for certificate request for \'' . $this->basename . '\'. Cannot save certificate.');
+                } elseif ($this->log >= LEClient::LOG_STATUS) {
+                    LEFunctions::log('Invalid response for certificate request for \'' . $this->basename . '\'. Cannot save certificate.', 'function getCertificate');
+                }
+            }
+        } else {
+            if ($this->log instanceof \Psr\Log\LoggerInterface) {
+                $this->log->info('Order for \'' . $this->basename . '\' not valid. Cannot retrieve certificate.');
+            } elseif ($this->log >= LEClient::LOG_STATUS) {
+                LEFunctions::log('Order for \'' . $this->basename . '\' not valid. Cannot retrieve certificate.', 'function getCertificate');
+            }
+        }
+
+        return false;
+    }
 
     /**
      * Revokes the certificate in the current LetsEncrypt Order instance, if existent. Unlike stated in the ACME draft, the certificate revoke request cannot be signed
-	 * with the account private key, and will be signed with the certificate private key.
+     * with the account private key, and will be signed with the certificate private key.
      *
      * @param int	$reason   The reason to revoke the LetsEncrypt Order instance certificate. Possible reasons can be found in section 5.3.1 of RFC5280.
      *
      * @return boolean	Returns true if the certificate was successfully revoked, false if not.
      */
-	public function revokeCertificate($reason = 0)
-	{
-		if($this->status == 'valid')
-		{
-			if (isset($this->certificateKeys['certificate'])) $certFile = $this->certificateKeys['certificate'];
-			elseif (isset($this->certificateKeys['fullchain_certificate']))  $certFile = $this->certificateKeys['fullchain_certificate'];
-			else throw new \RuntimeException('certificateKeys[certificate] or certificateKeys[fullchain_certificate] required');
+    public function revokeCertificate($reason = 0)
+    {
+        if ($this->status == 'valid') {
+            if (isset($this->certificateKeys['certificate'])) {
+                $certFile = $this->certificateKeys['certificate'];
+            } elseif (isset($this->certificateKeys['fullchain_certificate'])) {
+                $certFile = $this->certificateKeys['fullchain_certificate'];
+            } else {
+                throw new \RuntimeException('certificateKeys[certificate] or certificateKeys[fullchain_certificate] required');
+            }
 
-			if(file_exists($certFile) && file_exists($this->certificateKeys['private_key']))
-			{
-				$certificate = file_get_contents($this->certificateKeys['certificate']);
-				preg_match('~-----BEGIN\sCERTIFICATE-----(.*)-----END\sCERTIFICATE-----~s', $certificate, $matches);
-				$certificate = trim(LEFunctions::Base64UrlSafeEncode(base64_decode(trim($matches[1]))));
+            if (file_exists($certFile) && file_exists($this->certificateKeys['private_key'])) {
+                $certificate = file_get_contents($this->certificateKeys['certificate']);
 
-				$sign = $this->connector->signRequestJWK(array('certificate' => $certificate, 'reason' => $reason), $this->connector->revokeCert, $this->certificateKeys['private_key']);
-				$post = $this->connector->post($this->connector->revokeCert, $sign);
-				if(strpos($post['header'], "200 OK") !== false)
-				{
-					if($this->log instanceof \Psr\Log\LoggerInterface) 
-					{
-						$this->log->info('Certificate for order \'' . $this->basename . '\' revoked.');
-					}
-					elseif($this->log >= LEClient::LOG_STATUS) LEFunctions::log('Certificate for order \'' . $this->basename . '\' revoked.', 'function revokeCertificate');
-					return true;
-				}
-				else
-				{
-					if($this->log instanceof \Psr\Log\LoggerInterface) 
-					{
-						$this->log->info('Certificate for order \'' . $this->basename . '\' cannot be revoked.');
-					}
-					elseif($this->log >= LEClient::LOG_STATUS) LEFunctions::log('Certificate for order \'' . $this->basename . '\' cannot be revoked.', 'function revokeCertificate');
-				}
-			}
-			else
-			{
-				if($this->log instanceof \Psr\Log\LoggerInterface) 
-				{
-					$this->log->info('Certificate for order \'' . $this->basename . '\' not found. Cannot revoke certificate.');
-				}
-				elseif($this->log >= LEClient::LOG_STATUS) LEFunctions::log('Certificate for order \'' . $this->basename . '\' not found. Cannot revoke certificate.', 'function revokeCertificate');
-			}
-		}
-		else
-		{
-			if($this->log instanceof \Psr\Log\LoggerInterface) 
-			{
-				$this->log->info('Order for \'' . $this->basename . '\' not valid. Cannot revoke certificate.');
-			}
-			elseif($this->log >= LEClient::LOG_STATUS) LEFunctions::log('Order for \'' . $this->basename . '\' not valid. Cannot revoke certificate.', 'function revokeCertificate');
-		}
-		return false;
-	}
+                preg_match('~-----BEGIN\sCERTIFICATE-----(.*)-----END\sCERTIFICATE-----~s', $certificate, $matches);
+
+                $certificate = trim(LEFunctions::Base64UrlSafeEncode(base64_decode(trim($matches[1]))));
+
+                $sign = $this->connector->signRequestJWK(['certificate' => $certificate, 'reason' => $reason], $this->connector->revokeCert, $this->certificateKeys['private_key']);
+                $post = $this->connector->post($this->connector->revokeCert, $sign);
+
+                if (strpos($post['header'], "200 OK") !== false) {
+                    if ($this->log instanceof \Psr\Log\LoggerInterface) {
+                        $this->log->info('Certificate for order \'' . $this->basename . '\' revoked.');
+                    } elseif ($this->log >= LEClient::LOG_STATUS) {
+                        LEFunctions::log('Certificate for order \'' . $this->basename . '\' revoked.', 'function revokeCertificate');
+                    }
+
+                    return true;
+                } else {
+                    if ($this->log instanceof \Psr\Log\LoggerInterface) {
+                        $this->log->info('Certificate for order \'' . $this->basename . '\' cannot be revoked.');
+                    } elseif ($this->log >= LEClient::LOG_STATUS) {
+                        LEFunctions::log('Certificate for order \'' . $this->basename . '\' cannot be revoked.', 'function revokeCertificate');
+                    }
+                }
+            } else {
+                if ($this->log instanceof \Psr\Log\LoggerInterface) {
+                    $this->log->info('Certificate for order \'' . $this->basename . '\' not found. Cannot revoke certificate.');
+                } elseif ($this->log >= LEClient::LOG_STATUS) {
+                    LEFunctions::log('Certificate for order \'' . $this->basename . '\' not found. Cannot revoke certificate.', 'function revokeCertificate');
+                }
+            }
+        } else {
+            if ($this->log instanceof \Psr\Log\LoggerInterface) {
+                $this->log->info('Order for \'' . $this->basename . '\' not valid. Cannot revoke certificate.');
+            } elseif ($this->log >= LEClient::LOG_STATUS) {
+                LEFunctions::log('Order for \'' . $this->basename . '\' not valid. Cannot revoke certificate.', 'function revokeCertificate');
+            }
+        }
+
+        return false;
+    }
 }

--- a/src/LEOrder.php
+++ b/src/LEOrder.php
@@ -642,7 +642,7 @@ class LEOrder
      */
     public function isFinalized()
     {
-        return ($this->status == 'processing' || $this->status == 'valid');
+        return ($this->status === 'processing' || $this->status === 'valid' || $this->status === 'ready');
     }
 
     /**
@@ -669,7 +669,7 @@ class LEOrder
             $polling++;
         }
 
-        if ($this->status == 'valid' && !empty($this->certificateURL)) {
+        if (($this->status === 'valid' || $this->status === 'ready') && !empty($this->certificateURL)) {
             $get = $this->connector->get($this->certificateURL);
 
             if ($get['status'] === 200) {
@@ -730,7 +730,7 @@ class LEOrder
      */
     public function revokeCertificate($reason = 0)
     {
-        if ($this->status == 'valid') {
+        if ($this->status === 'valid' || $this->status === 'ready') {
             if (isset($this->certificateKeys['certificate'])) {
                 $certFile = $this->certificateKeys['certificate'];
             } elseif (isset($this->certificateKeys['fullchain_certificate'])) {


### PR DESCRIPTION
I used a tool to automatically fix coding standards (PSR2) and code reformatting. You can find this tool here: https://github.com/FriendsOfPHP/PHP-CS-Fixer

Besides code style and reformatting code this PR includes:
- An unused variable has been removed
- Added more whitespace to improve readability
- Unnecessary "else" statements has been removed
- Consistency in the use of logical operators
- Due to a typo, the $certificatesKeys property is unused ([commit](https://github.com/RogierW/LEClient/commit/383f4f6b5eac573dbb700ebebbdb5a9437efc3ce))