### PR TITLE
fix Invalid response, header: HTTP/2 200 

### DIFF
--- a/src/LEAccount.php
+++ b/src/LEAccount.php
@@ -96,7 +96,7 @@ class LEAccount
 
 		$sign = $this->connector->signRequestJWK(array('contact' => $contact, 'termsOfServiceAgreed' => true), $this->connector->newAccount);
 		$post = $this->connector->post($this->connector->newAccount, $sign);
-		if(strpos($post['header'], "201 Created") !== false)
+		if($post['status'] === 201)
 		{
 			if(preg_match('~Location: (\S+)~i', $post['header'], $matches)) return trim($matches[1]);
 		}
@@ -113,7 +113,7 @@ class LEAccount
 		$sign = $this->connector->signRequestJWK(array('onlyReturnExisting' => true), $this->connector->newAccount);
 		$post = $this->connector->post($this->connector->newAccount, $sign);
 
-		if(strpos($post['header'], "200 OK") !== false)
+		if($post['status'] === 200)
 		{
 			if(preg_match('~Location: (\S+)~i', $post['header'], $matches)) return trim($matches[1]);
 		}
@@ -127,7 +127,7 @@ class LEAccount
 	{
 		$sign = $this->connector->signRequestKid(array('' => ''), $this->connector->accountURL, $this->connector->accountURL);
 		$post = $this->connector->post($this->connector->accountURL, $sign);
-		if(strpos($post['header'], "200 OK") !== false)
+		if($post['status'] === 200)
 		{
 			$this->id = isset($post['body']['id']) ? $post['body']['id'] : '';
 			$this->key = $post['body']['key'];
@@ -156,7 +156,7 @@ class LEAccount
 
 		$sign = $this->connector->signRequestKid(array('contact' => $contact), $this->connector->accountURL, $this->connector->accountURL);
 		$post = $this->connector->post($this->connector->accountURL, $sign);
-		if(strpos($post['header'], "200 OK") !== false)
+		if($post['status'] === 200)
 		{
 			$this->id = $post['body']['id'];
 			$this->key = $post['body']['key'];
@@ -196,7 +196,7 @@ class LEAccount
 		$outerPayload = $this->connector->signRequestJWK($innerPayload, $this->connector->keyChange, $this->accountKeys['private_key'].'.new');
 		$sign = $this->connector->signRequestKid($outerPayload, $this->connector->accountURL, $this->connector->keyChange);
 		$post = $this->connector->post($this->connector->keyChange, $sign);
-		if(strpos($post['header'], "200 OK") !== false)
+		if($post['status'] === 200)
 		{
 			unlink($this->accountKeys['private_key']);
 			unlink($this->accountKeys['public_key']);
@@ -227,7 +227,7 @@ class LEAccount
 	{
 		$sign = $this->connector->signRequestKid(array('status' => 'deactivated'), $this->connector->accountURL, $this->connector->accountURL);
 		$post = $this->connector->post($this->connector->accountURL, $sign);
-		if(strpos($post['header'], "200 OK") !== false)
+		if($post['status'] === 200)
 		{
 			$this->connector->accountDeactivated = true;
 			if($this->log instanceof \Psr\Log\LoggerInterface) 

--- a/src/LEAuthorization.php
+++ b/src/LEAuthorization.php
@@ -61,7 +61,7 @@ class LEAuthorization
 		$this->authorizationURL = $authorizationURL;
 
 		$get = $this->connector->get($this->authorizationURL);
-		if(strpos($get['header'], "200 OK") !== false)
+		if($get['status'] === 200)
 		{
 			$this->identifier = $get['body']['identifier'];
 			$this->status = $get['body']['status'];
@@ -85,7 +85,7 @@ class LEAuthorization
 	public function updateData()
 	{
 		$get = $this->connector->get($this->authorizationURL);
-		if(strpos($get['header'], "200 OK") !== false)
+		if($get['status'] === 200)
 		{
 			$this->identifier = $get['body']['identifier'];
 			$this->status = $get['body']['status'];

--- a/src/LEOrder.php
+++ b/src/LEOrder.php
@@ -107,7 +107,7 @@ class LEOrder
 			if (filter_var($this->orderURL, FILTER_VALIDATE_URL))
 			{
 				$get = $this->connector->get($this->orderURL);
-				if(strpos($get['header'], "200 OK") !== false && $get['body']['status'] != "invalid")
+				if($get['status'] === 200 && $get['body']['status'] != "invalid")
 				{
 					$orderdomains = array_map(function($ident) { return $ident['value']; }, $get['body']['identifiers']);
 					$diff = array_merge(array_diff($orderdomains, $domains), array_diff($domains, $orderdomains));
@@ -198,7 +198,7 @@ class LEOrder
 			$sign = $this->connector->signRequestKid($payload, $this->connector->accountURL, $this->connector->newOrder);
 			$post = $this->connector->post($this->connector->newOrder, $sign);
 
-			if(strpos($post['header'], "201 Created") !== false)
+			if($post['status'] === 201)
 			{
 				if(preg_match('~Location: (\S+)~i', $post['header'], $matches))
 				{
@@ -253,7 +253,7 @@ class LEOrder
 	private function updateOrderData()
 	{
 		$get = $this->connector->get($this->orderURL);
-		if(strpos($get['header'], "200 OK") !== false)
+		if($get['status'] === 200)
 		{
 			$this->status = $get['body']['status'];
 			$this->expires = $get['body']['expires'];
@@ -398,7 +398,7 @@ class LEOrder
 								{
 									$sign = $this->connector->signRequestKid(array('keyAuthorization' => $keyAuthorization), $this->connector->accountURL, $challenge['url']);
 									$post = $this->connector->post($challenge['url'], $sign);
-									if(strpos($post['header'], "200 OK") !== false)
+									if($post['status'] === 200)
 									{
 										if($localcheck)
 										{
@@ -431,7 +431,7 @@ class LEOrder
 								{
 									$sign = $this->connector->signRequestKid(array('keyAuthorization' => $keyAuthorization), $this->connector->accountURL, $challenge['url']);
 									$post = $this->connector->post($challenge['url'], $sign);
-									if(strpos($post['header'], "200 OK") !== false)
+									if($post['status'] === 200)
 									{
 										if($localcheck)
 										{
@@ -481,7 +481,7 @@ class LEOrder
 			{
 				$sign = $this->connector->signRequestKid(array('status' => 'deactivated'), $this->connector->accountURL, $auth->authorizationURL);
 				$post = $this->connector->post($auth->authorizationURL, $sign);
-				if(strpos($post['header'], "200 OK") !== false)
+				if($post['status'] === 200)
 				{
 					if($this->log instanceof \Psr\Log\LoggerInterface) 
 					{
@@ -573,7 +573,7 @@ class LEOrder
 				$csr = trim(LEFunctions::Base64UrlSafeEncode(base64_decode($csr)));
 				$sign = $this->connector->signRequestKid(array('csr' => $csr), $this->connector->accountURL, $this->finalizeURL);
 				$post = $this->connector->post($this->finalizeURL, $sign);
-				if(strpos($post['header'], "200 OK") !== false)
+				if($post['status'] === 200)
 				{
 					$this->status = $post['body']['status'];
 					$this->expires = $post['body']['expires'];
@@ -643,7 +643,7 @@ class LEOrder
 		if($this->status == 'valid' && !empty($this->certificateURL))
 		{
 			$get = $this->connector->get($this->certificateURL);
-			if(strpos($get['header'], "200 OK") !== false)
+			if($get['status'] === 200)
 			{
 				if(preg_match_all('~(-----BEGIN\sCERTIFICATE-----[\s\S]+?-----END\sCERTIFICATE-----)~i', $get['body'], $matches))
 				{
@@ -718,7 +718,7 @@ class LEOrder
 
 				$sign = $this->connector->signRequestJWK(array('certificate' => $certificate, 'reason' => $reason), $this->connector->revokeCert, $this->certificateKeys['private_key']);
 				$post = $this->connector->post($this->connector->revokeCert, $sign);
-				if(strpos($post['header'], "200 OK") !== false)
+				if($post['status'] === 200)
 				{
 					if($this->log instanceof \Psr\Log\LoggerInterface) 
 					{


### PR DESCRIPTION
We encountered an error while renewing certificates: `Invalid response, header: HTTP/2 200 `, which shows a breaking change in Let's Encrypt API. It's more robust to check status code directly instead of looking for "200 OK" or something in header.