### PR TITLE
Not to validate certificate in HTTP challenge

### DIFF
--- a/src/LEFunctions.php
+++ b/src/LEFunctions.php
@@ -208,6 +208,7 @@ class LEFunctions
         curl_setopt($handle, CURLOPT_URL, $requestURL);
         curl_setopt($handle, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($handle, CURLOPT_FOLLOWLOCATION, true);
+	curl_setopt($handle, CURLOPT_SSL_VERIFYPEER, false);	
         $response = trim(curl_exec($handle));
 
 		return (!empty($response) && $response == $keyAuthorization);


### PR DESCRIPTION
Curl rejects http response if the url is redirected to a https resource with self-signed/expired certificate.
Whereas lets encrypt validates such URLs.
ref: https://letsencrypt.org/docs/challenge-types/ -- Search for "When redirected to an HTTPS URL, it does not validate certificates"