### PR TITLE
Search all authorizations for valid challenges

### DIFF
--- a/src/LEOrder.php
+++ b/src/LEOrder.php
@@ -2,6 +2,7 @@
 
 namespace LEClient;
 
+use LEClient\Exceptions\LEAuthorizationException;
 use LEClient\Exceptions\LEOrderException;
 
 /**
@@ -343,7 +344,11 @@ class LEOrder
 		{
 			if($auth->status == 'pending')
 			{
-				$challenge = $auth->getChallenge($type);
+				try {
+					$challenge = $auth->getChallenge($type);
+				} catch (LEAuthorizationException $e) {
+					continue;
+				}
 				if($challenge['status'] == 'pending')
 				{
 					$keyAuthorization = $challenge['token'] . '.' . $digest;


### PR DESCRIPTION
When returning all pending authorizations for a given challenge type, don't fail when an authorization doesn't contain that challenge type.

Closes: #112 